### PR TITLE
Use performance.now instead of Date.now

### DIFF
--- a/frontend/src/hooks/useThrottle.ts
+++ b/frontend/src/hooks/useThrottle.ts
@@ -8,7 +8,7 @@ export function useThrottle(value: string, interval = 500) {
   const lastUpdated = React.useRef<number | null>(null);
 
   React.useEffect(() => {
-    const now = Date.now();
+    const now = performance.now();
 
     if (!lastUpdated.current || now >= lastUpdated.current + interval) {
       lastUpdated.current = now;


### PR DESCRIPTION
Minor tweak, see documentation on MDN:
[https://developer.mozilla.org/en-US/docs/Web/API/Performance/now](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now)