### PR TITLE
small fix, check that dataUrls are valid

### DIFF
--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -106,7 +106,9 @@ function ImageUpload({ setReferenceImages }: Props) {
       // Convert images to data URLs and set the prompt images state
       Promise.all(files.map((file) => fileToDataURL(file)))
         .then((dataUrls) => {
-          setReferenceImages(dataUrls.map((dataUrl) => dataUrl as string));
+          if(dataUrls.length > 0) {
+            setReferenceImages(dataUrls.map((dataUrl) => dataUrl as string));
+          }
         })
         .catch((error) => {
           // TODO: Display error to user


### PR DESCRIPTION
Fix because every paste in textarea will show error message and replace image canvas with empty image

From https://github.com/ntsd/screenshot-to-code/pull/1
feat: https://github.com/abi/screenshot-to-code/pull/19