### PR TITLE
Feat/support ionic lenguage

### DIFF
--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -44,16 +44,16 @@ def build_prompt(prompt, params):
         prompt = prompt.replace(placeholder, value)
     return prompt
 
-def add_support_lenguages(prompt):
+def add_support_lenguages(prompt, params):
     support_lenguage = "\n".join([IONIC_PROMPT_SUPPORT])
-    prompt = build_prompt(prompt, {'support_lenguage': support_lenguage })
+    prompt = build_prompt(prompt, {'support_lenguage': support_lenguage, **params })
     return prompt
 
 def get_prompt(prompt, params = {}):
     params_template = {**SYSTEM_PROMPT_PARAMS, **params}
     
     prompt_template = build_prompt(prompt, params_template)
-    prompt_template = add_support_lenguages(prompt_template)
+    prompt_template = add_support_lenguages(prompt_template, params_template)
 
     return prompt_template
 

--- a/backend/support_lenguage.py
+++ b/backend/support_lenguage.py
@@ -1,0 +1,8 @@
+IONIC_PROMPT_SUPPORT =  """
+Keep in mind if in the following instruction you are also an expert in Ionic, include this libraries, 
+otherwise only those related to {{main_language_name}} and other languages not related to Ionic:
+
+- <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+- <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
+- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+"""

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -106,7 +106,9 @@ function ImageUpload({ setReferenceImages }: Props) {
       // Convert images to data URLs and set the prompt images state
       Promise.all(files.map((file) => fileToDataURL(file)))
         .then((dataUrls) => {
-          setReferenceImages(dataUrls.map((dataUrl) => dataUrl as string));
+          if(dataUrls.length > 0) {
+            setReferenceImages(dataUrls.map((dataUrl) => dataUrl as string));
+          }
         })
         .catch((error) => {
           // TODO: Display error to user


### PR DESCRIPTION
add support Ionic from CDN, this add basic support without another framework, read https://ionicframework.com/docs/intro/cdn

```
- <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
- <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
```

Only implements "Ionic" if the Prompt is required to be used:

![screenshot_to_code_ionic](https://github.com/abi/screenshot-to-code/assets/8028861/4d05f603-5cc8-4dab-9b44-c84b32ede1bb)


Additionally, "{{}}" tags are used to allow setting of Prompts with parameters:

```
....
- Use this script to include {{css_library_name}}: {{css_library_script}}
...
``` 