### PR TITLE
Feat: support generate react code

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -100,10 +100,16 @@ async def stream_code(websocket: WebSocket):
     if params.get("resultImage") and params["resultImage"]:
         prompt_messages = assemble_prompt(params["image"], params["resultImage"])
     else:
-        prompt_messages = assemble_prompt(params["image"])
+        if params.get("codeType") and params["codeType"] == "react":
+            prompt_messages = assemble_prompt(
+                params["image"], is_react=True
+            )
+        else:
+            prompt_messages = assemble_prompt(params["image"])
 
     # Image cache for updates so that we don't have to regenerate images
     image_cache = {}
+
 
     if params["generationType"] == "update":
         # Transform into message format

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -39,7 +39,7 @@ padding, margin, border, etc. Match the colors and sizes exactly.
 In terms of libraries, assume that all libraries are already install, you can import it if you want to use it.
 
 Strictly return only the full jsx code,
-Do not include markdown "```" or "```jsx" at the start or end, do not include other information or explanation.
+Strictly do not return markdown "```" or "```jsx" at the start or end, do not return other information or explanation.
 """
 
 USER_PROMPT = """

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -23,11 +23,30 @@ Return only the full code in <html></html> tags.
 Do not include markdown "```" or "```html" at the start or end.
 """
 
+REACT_GENERATION_SYSTEM_PROMPT = """
+You are an expert React developer
+You take screenshots of a reference web page from the user, and then build single page apps 
+using React, Tailwind, and JS.
+
+- Make sure the app looks exactly like the screenshot.
+- Pay close attention to background color, text color, font size, font family, 
+padding, margin, border, etc. Match the colors and sizes exactly.
+- Use the exact text from the screenshot.
+- Do not add comments in the code such as "{/**  ... other news items ... */}" in place of writing the full code. WRITE THE FULL CODE.
+- Repeat elements as needed to match the screenshot. For example, if there are 15 items, the code should have 15 items. DO NOT LEAVE comments like "{/** Repeat for each news item */}" or bad things will happen.
+- For images, use placeholder images from https://placehold.co and include a detailed description of the image in the alt text so that an image generation AI can generate the image later.
+
+In terms of libraries, assume that all libraries are already install, you can import it if you want to use it.
+
+Strictly return only the full jsx code,
+Do not include markdown "```" or "```jsx" at the start or end, do not include other information or explanation.
+"""
+
 USER_PROMPT = """
 Generate code for a web page that looks exactly like this.
 """
 
-def assemble_prompt(image_data_url, result_image_data_url=None):
+def assemble_prompt(image_data_url, result_image_data_url=None, is_react=False):
     content = [
         {
             "type": "image_url",
@@ -44,7 +63,7 @@ def assemble_prompt(image_data_url, result_image_data_url=None):
             "image_url": {"url": result_image_data_url, "detail": "high"},
         })
     return [
-        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "system", "content": SYSTEM_PROMPT if not is_react else REACT_GENERATION_SYSTEM_PROMPT},
         {
             "role": "user",
             "content": content,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,12 @@
-import { useRef, useState, useCallback } from "react";
+import { useRef, useState } from "react";
 import ImageUpload from "./components/ImageUpload";
 import CodePreview from "./components/CodePreview";
 import Preview from "./components/Preview";
-import { CodeGenerationParams, generateCode } from "./generateCode";
+import { CodeGenerationParams, CodeType, generateCode } from "./generateCode";
 import Spinner from "./components/Spinner";
 import classNames from "classnames";
 import {
   FaCode,
-  FaCopy,
   FaDesktop,
   FaDownload,
   FaMobile,
@@ -31,6 +30,7 @@ import { UrlInputSection } from "./components/UrlInputSection";
 import TermsOfServiceDialog from "./components/TermsOfServiceDialog";
 import html2canvas from "html2canvas";
 import { USER_CLOSE_WEB_SOCKET_CODE } from "./constants";
+import { ReactCodePreview } from "./components/ReactCodePreview";
 
 function App() {
   const [appState, setAppState] = useState<AppState>(AppState.INITIAL);
@@ -120,6 +120,7 @@ function App() {
     if (referenceImages.length > 0) {
       doGenerateCode({
         generationType: "create",
+        codeType: CodeType.HTML,
         image: referenceImages[0],
       });
     }
@@ -132,6 +133,7 @@ function App() {
       const resultImage = await takeScreenshot();
       doGenerateCode({
         generationType: "update",
+        codeType: CodeType.HTML,
         image: referenceImages[0],
         resultImage: resultImage,
         history: updatedHistory,
@@ -139,6 +141,7 @@ function App() {
     } else {
       doGenerateCode({
         generationType: "update",
+        codeType: CodeType.HTML,
         image: referenceImages[0],
         history: updatedHistory,
       });
@@ -149,10 +152,10 @@ function App() {
     setUpdateInstruction("");
   }
 
-  const doCopyCode = useCallback(() => {
-    copy(generatedCode);
+  const doCopyCode = (code: string) => {
+    copy(code);
     toast.success("Copied to clipboard");
-  }, [generatedCode]);
+  };
 
   const handleTermDialogOpenChange = (open: boolean) => {
     setSettings((s) => ({
@@ -305,6 +308,7 @@ function App() {
                     Code
                   </TabsTrigger>
                 </TabsList>
+                <ReactCodePreview doGenerateCode={doGenerateCode} referenceImage={referenceImages[0]} />
               </div>
               <TabsContent value="desktop">
                 <Preview code={generatedCode} device="desktop" />
@@ -313,20 +317,12 @@ function App() {
                 <Preview code={generatedCode} device="mobile" />
               </TabsContent>
               <TabsContent value="code">
-                <div className="relative">
-                  <CodeMirror
+                <CodeMirror
                     code={generatedCode}
                     editorTheme={settings.editorTheme}
                     onCodeChange={setGeneratedCode}
-                  />
-                  <span
-                    title="Copy Code"
-                    className="flex items-center justify-center w-10 h-10 text-gray-500 hover:bg-gray-100 cursor-pointer rounded-lg text-sm p-2.5 absolute top-[20px] right-[20px]"
-                    onClick={doCopyCode}
-                  >
-                    <FaCopy />
-                  </span>
-                </div>
+                    doCopyCode={() => doCopyCode(generatedCode)}
+                />
               </TabsContent>
             </Tabs>
           </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,8 +14,6 @@ import {
 } from "react-icons/fa";
 
 import { Switch } from "./components/ui/switch";
-import copy from "copy-to-clipboard";
-import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/tabs";
@@ -30,7 +28,8 @@ import { UrlInputSection } from "./components/UrlInputSection";
 import TermsOfServiceDialog from "./components/TermsOfServiceDialog";
 import html2canvas from "html2canvas";
 import { USER_CLOSE_WEB_SOCKET_CODE } from "./constants";
-import { ReactCodePreview } from "./components/ReactCodePreview";
+import { ReactCodeEditor } from "./components/ReactCodeEditor";
+import { doCopyCode } from "./lib/utils";
 
 function App() {
   const [appState, setAppState] = useState<AppState>(AppState.INITIAL);
@@ -151,11 +150,6 @@ function App() {
     setGeneratedCode("");
     setUpdateInstruction("");
   }
-
-  const doCopyCode = (code: string) => {
-    copy(code);
-    toast.success("Copied to clipboard");
-  };
 
   const handleTermDialogOpenChange = (open: boolean) => {
     setSettings((s) => ({
@@ -308,7 +302,7 @@ function App() {
                     Code
                   </TabsTrigger>
                 </TabsList>
-                <ReactCodePreview doGenerateCode={doGenerateCode} referenceImage={referenceImages[0]} />
+                <ReactCodeEditor doGenerateCode={doGenerateCode} referenceImage={referenceImages[0]} />
               </div>
               <TabsContent value="desktop">
                 <Preview code={generatedCode} device="desktop" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -302,7 +302,7 @@ function App() {
                     Code
                   </TabsTrigger>
                 </TabsList>
-                <ReactCodeEditor doGenerateCode={doGenerateCode} referenceImage={referenceImages[0]} />
+                <ReactCodeEditor doGenerateCode={doGenerateCode} referenceImage={referenceImages[0]} appState={appState} />
               </div>
               <TabsContent value="desktop">
                 <Preview code={generatedCode} device="desktop" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,7 +96,7 @@ function App() {
     setAppState(AppState.CODE_READY);
   };
 
-  function doGenerateCode(params: CodeGenerationParams) {
+  function doGenerateCode(params: CodeGenerationParams, setCode: (value: React.SetStateAction<string>) => void = setGeneratedCode) {
     setExecutionConsole([]);
     setAppState(AppState.CODING);
 
@@ -106,8 +106,8 @@ function App() {
     generateCode(
       wsRef,
       updatedParams,
-      (token) => setGeneratedCode((prev) => prev + token),
-      (code) => setGeneratedCode(code),
+      (token) => setCode((prev) => prev + token),
+      (code) => setCode(code),
       (line) => setExecutionConsole((prev) => [...prev, line]),
       () => setAppState(AppState.CODE_READY)
     );

--- a/frontend/src/components/CodeMirror.tsx
+++ b/frontend/src/components/CodeMirror.tsx
@@ -12,14 +12,16 @@ import {
 import { bracketMatching } from "@codemirror/language";
 import { html } from "@codemirror/lang-html";
 import { EditorTheme } from "@/types";
+import { FaCopy } from "react-icons/fa";
 
 interface Props {
   code: string;
   editorTheme: EditorTheme;
   onCodeChange: (code: string) => void;
+  doCopyCode: () => void;
 }
 
-function CodeMirror({ code, editorTheme, onCodeChange }: Props) {
+function CodeMirror({ code, editorTheme, onCodeChange, doCopyCode }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const view = useRef<EditorView | null>(null);
   const editorState = useMemo(() => EditorState.create({
@@ -67,7 +69,16 @@ function CodeMirror({ code, editorTheme, onCodeChange }: Props) {
   }, [code]);
 
   return (
-    <div className="overflow-x-scroll overflow-y-scroll mx-2 border-[4px] border-black rounded-[20px]" ref={ref} />
+    <div className="relative">
+        <div className="overflow-x-scroll overflow-y-scroll mx-2 border-[4px] border-black rounded-[20px]" ref={ref} />
+        <span
+          title="Copy Code"
+          className="flex items-center justify-center w-10 h-10 text-gray-500 hover:bg-gray-100 cursor-pointer rounded-lg text-sm p-2.5 absolute top-[20px] right-[20px]"
+          onClick={doCopyCode}
+        >
+        <FaCopy />
+      </span>
+    </div>
   );
 }
 

--- a/frontend/src/components/CodeMirror.tsx
+++ b/frontend/src/components/CodeMirror.tsx
@@ -11,6 +11,7 @@ import {
 } from "@codemirror/commands";
 import { bracketMatching } from "@codemirror/language";
 import { html } from "@codemirror/lang-html";
+import { javascript } from "@codemirror/lang-javascript";
 import { EditorTheme } from "@/types";
 import { FaCopy } from "react-icons/fa";
 
@@ -35,6 +36,7 @@ function CodeMirror({ code, editorTheme, onCodeChange, doCopyCode }: Props) {
       ]),
       lineNumbers(),
       bracketMatching(),
+      javascript(), // Added JavaScript support
       html(),
       editorTheme === EditorTheme.ESPRESSO ? espresso : cobalt,
       EditorView.lineWrapping,
@@ -73,7 +75,7 @@ function CodeMirror({ code, editorTheme, onCodeChange, doCopyCode }: Props) {
         <div className="overflow-x-scroll overflow-y-scroll mx-2 border-[4px] border-black rounded-[20px]" ref={ref} />
         <span
           title="Copy Code"
-          className="flex items-center justify-center w-10 h-10 text-gray-500 hover:bg-gray-100 cursor-pointer rounded-lg text-sm p-2.5 absolute top-[20px] right-[20px]"
+          className="flex items-center justify-center text-gray-500 hover:bg-gray-100 cursor-pointer rounded-lg text-sm p-2.5 absolute top-[0px] right-[20px]"
           onClick={doCopyCode}
         >
         <FaCopy />

--- a/frontend/src/components/ReactCodeEditor.tsx
+++ b/frontend/src/components/ReactCodeEditor.tsx
@@ -19,7 +19,7 @@ import { Textarea } from "./ui/textarea";
 
 
 interface IProps {
-    doGenerateCode: (params: CodeGenerationParams) => void;
+    doGenerateCode: (params: CodeGenerationParams, setCode: (value: React.SetStateAction<string>) => void) => void;
     referenceImage: string;
 }
 
@@ -44,7 +44,7 @@ export const ReactCodeEditor: React.FC<IProps> = ({ doGenerateCode, referenceIma
             codeType: CodeType.REACT,
             image: referenceImage,
             history: updatedHistory,
-        });
+        }, setGeneratedReactCode);
 
         setReactHistory(updatedHistory);
         setGeneratedReactCode("");

--- a/frontend/src/components/ReactCodeEditor.tsx
+++ b/frontend/src/components/ReactCodeEditor.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 import { FaReact } from "react-icons/fa"
 import CodeMirror from "./CodeMirror";
 import { usePersistedState } from "@/hooks/usePersistedState";
-import { EditorTheme, Settings } from "@/types";
+import { AppState, EditorTheme, Settings } from "@/types";
 import { doCopyCode } from "@/lib/utils";
 import { Textarea } from "./ui/textarea";
 
@@ -21,9 +21,10 @@ import { Textarea } from "./ui/textarea";
 interface IProps {
     doGenerateCode: (params: CodeGenerationParams, setCode: (value: React.SetStateAction<string>) => void) => void;
     referenceImage: string;
+    appState: AppState;
 }
 
-export const ReactCodeEditor: React.FC<IProps> = ({ doGenerateCode, referenceImage }) => {
+export const ReactCodeEditor: React.FC<IProps> = ({ doGenerateCode, referenceImage, appState }) => {
     const [generatedReactCode, setGeneratedReactCode] = useState("");
     const [updateInstruction, setUpdateInstruction] = useState("");
     const [reactHistory, setReactHistory] = useState<string[]>([]);
@@ -51,19 +52,32 @@ export const ReactCodeEditor: React.FC<IProps> = ({ doGenerateCode, referenceIma
         setUpdateInstruction("");
     }
 
+    async function init() {
+        doGenerateCode({
+            generationType: "create",
+            codeType: CodeType.REACT,
+            image: referenceImage,
+            history: [],
+        }, setGeneratedReactCode);
+    }
+
     return (
-    <Dialog>
+    <Dialog onOpenChange={(open: boolean) => {
+        if (open && generatedReactCode === "") {
+            init();
+        }
+    }}>
         <DialogTrigger asChild>
         <Button className="flex items-center gap-x-2 ml-4"><FaReact /> Generate React Code</Button>
         </DialogTrigger>
-        <DialogContent className="sm:min-w-[425px] lg:min-w-[1240px] min-h-[600px] flex flex-col justify-between">
+        <DialogContent className="sm:min-w-[425px] lg:min-w-[1240px] h-[660px] flex flex-col justify-between">
             <DialogHeader>
                 <DialogTitle>Generate React Code</DialogTitle>
                 <DialogDescription>
                 Notice: The code below may shows different results than the HTML code.
                 </DialogDescription>
             </DialogHeader>
-            <div className="gap-2 flex-1">
+            <div className="gap-2 flex-1 overflow-scroll">
                 <CodeMirror
                     editorTheme={settings.editorTheme}
                     code={generatedReactCode}
@@ -77,7 +91,7 @@ export const ReactCodeEditor: React.FC<IProps> = ({ doGenerateCode, referenceIma
                 value={updateInstruction}
             />
             <DialogFooter>
-                <Button onClick={doUpdateReact}>Update</Button>
+                <Button disabled={appState === AppState.CODING} onClick={doUpdateReact}>Update</Button>
             </DialogFooter>
         </DialogContent>
     </Dialog>

--- a/frontend/src/components/ReactCodeEditor.tsx
+++ b/frontend/src/components/ReactCodeEditor.tsx
@@ -1,0 +1,85 @@
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { CodeGenerationParams, CodeType } from "@/generateCode";
+import { useState } from "react";
+import { FaReact } from "react-icons/fa"
+import CodeMirror from "./CodeMirror";
+import { usePersistedState } from "@/hooks/usePersistedState";
+import { EditorTheme, Settings } from "@/types";
+import { doCopyCode } from "@/lib/utils";
+import { Textarea } from "./ui/textarea";
+
+
+interface IProps {
+    doGenerateCode: (params: CodeGenerationParams) => void;
+    referenceImage: string;
+}
+
+export const ReactCodeEditor: React.FC<IProps> = ({ doGenerateCode, referenceImage }) => {
+    const [generatedReactCode, setGeneratedReactCode] = useState("");
+    const [updateInstruction, setUpdateInstruction] = useState("");
+    const [reactHistory, setReactHistory] = useState<string[]>([]);
+    const [settings] = usePersistedState<Settings>(
+        {
+          openAiApiKey: null,
+          screenshotOneApiKey: null,
+          isImageGenerationEnabled: true,
+          editorTheme: EditorTheme.COBALT,
+          isTermOfServiceAccepted: false,
+        },
+        "setting"
+      );
+    async function doUpdateReact() {
+        const updatedHistory = [...reactHistory, generatedReactCode, updateInstruction];
+        doGenerateCode({
+            generationType: "update",
+            codeType: CodeType.REACT,
+            image: referenceImage,
+            history: updatedHistory,
+        });
+
+        setReactHistory(updatedHistory);
+        setGeneratedReactCode("");
+        setUpdateInstruction("");
+    }
+
+    return (
+    <Dialog>
+        <DialogTrigger asChild>
+        <Button className="flex items-center gap-x-2 ml-4"><FaReact /> Generate React Code</Button>
+        </DialogTrigger>
+        <DialogContent className="sm:min-w-[425px] lg:min-w-[1240px] min-h-[600px] flex flex-col justify-between">
+            <DialogHeader>
+                <DialogTitle>Generate React Code</DialogTitle>
+                <DialogDescription>
+                Notice: The code below may shows different results than the HTML code.
+                </DialogDescription>
+            </DialogHeader>
+            <div className="gap-2 flex-1">
+                <CodeMirror
+                    editorTheme={settings.editorTheme}
+                    code={generatedReactCode}
+                    onCodeChange={setGeneratedReactCode}
+                    doCopyCode={() => doCopyCode(generatedReactCode)}
+                />
+            </div>
+            <Textarea
+                placeholder="Tell the AI what to change..."
+                onChange={(e) => setUpdateInstruction(e.target.value)}
+                value={updateInstruction}
+            />
+            <DialogFooter>
+                <Button onClick={doUpdateReact}>Update</Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/generateCode.ts
+++ b/frontend/src/generateCode.ts
@@ -8,7 +8,7 @@ const ERROR_MESSAGE =
 const STOP_MESSAGE = "Code generation stopped";
 
 export enum CodeType {
-  HTML = "HTML",
+  HTML = "html",
   REACT = "react",
 }
 

--- a/frontend/src/generateCode.ts
+++ b/frontend/src/generateCode.ts
@@ -7,8 +7,14 @@ const ERROR_MESSAGE =
 
 const STOP_MESSAGE = "Code generation stopped";
 
+export enum CodeType {
+  HTML = "HTML",
+  REACT = "react",
+}
+
 export interface CodeGenerationParams {
   generationType: "create" | "update";
+  codeType: CodeType;
   image: string;
   resultImage?: string;
   history?: string[];

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,6 +1,13 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import copy from "copy-to-clipboard";
+import toast from "react-hot-toast";
  
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const doCopyCode = (code: string) => {
+  copy(code);
+  toast.success("Copied to clipboard");
+};


### PR DESCRIPTION
#96 

## Background

Now our system only supports generating HTML. However, the frontend community now mainly uses React, and Vue as development frameworks/libraries. Thus adding react generation capacity is crucial.

## Methods

There are two ways to generate react code:

1. **image → react**: Feed GPT the same materials as we generate HTML, and prompt GPT to generate React(and other) code.
2. **image → html → react**: Prompt GPT to translate HTML into React code.

Here are some simple investigations of the advantages of these two methods:

  | image → react | image → html → react
-- | -- | --
Accuracy | ✅ |  
Performance | ✅ |  
Token Cost | ✅ |  
Modularity | ✅ |  
Community | ✅ |  
Complexity |   | ✅

## Accuracy

There are certain accuracy losses when we use GPT to translate something, no matter if it is from image to code, or code to code. From this perspective, directly generating react code is expected to perform better than image → html → react.

### Performance/Token Cost

image → html → react requires at least 2 rounds of GPT query, while image → react requires at least 1 round of GPT query. So image → react outperforms image → html → react.

### Modularity

HTML makes it hard to abstract components. Image → react opens a door to **generate components** in the future, which is a good way to handle complexity especially when GPT’s capacity is not good enough for now.

### Community

Image → react allows GPT to utilize the npm libraries. Image → html → react hinders GPT from using the library when it is generating HTML, and the translation from HTML to react will follow the thought expressed in HTML.

### Complexity

image → html → react is way easier than generating image → react from a development effort perspective.

## System Design

For now, we still emphasize the HTML generation given that there isn’t a way to display the render result of react code directly(Plan to add in future leveraging code sandbox). So HTML should be always generated in every update. React code will be an extra button next to the tabs. In the future, if we plan to support other frameworks like Vue, we can add a selection for users.

1. Home Page

<img width="1295" alt="generate react code home" src="https://github.com/abi/screenshot-to-code/assets/53188310/a6ee0b24-2776-4449-a950-2ca77974431c">

We will make this tab lazy loaded by default, given that now it is not the main feature of our system, always generating two pieces of code makes a significant cost. 

2. React Code Dialog

We will separate the flow of react generation from HTML generation, which means that they will have different instructions and update history. Because two pieces of code should have different instructions.

A dialog is thus created for the user to preview React’s code and provide instructions for updating the code. (In the future, when we have the capacity to preview react code render result), we may remove this and reuse the home page of HTML totally.

The basic flow is: user open react generation dialog -> auto execute generate react code -> user modify code and input instructions -> click on update -> regenerate code.

<img width="1287" alt="generate react code dialog" src="https://github.com/abi/screenshot-to-code/assets/53188310/628d41cc-1efb-44da-8c28-945cd4a5aed1">

3. Interface
- Reuse /generate-code with a new param: `codeType`, when `codeType` is `react` use the `react` prompt.
- New prompt template: `REACT_GENERATION_SYSTEM_PROMPT`