### PR TITLE
Adding one-click deploy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ https://github.com/abi/screenshot-to-code/assets/23818/3fec0f77-44e8-4fb3-a769-a
 🆕 [Try it here (paid)](https://screenshottocode.com). Or see [Getting Started](#-getting-started) for local install instructions to use with your own API keys.
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/abiraja)
+
+## One-Click Deployment (Third-Party)
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=258)


### PR DESCRIPTION
Adding section enabling community access to one-click deployment templates. This addition offers users the option to quickly self-host the open source app with less expensive third-party hosting services, instead of exclusively showing a link to the official cloud product website with no other options.