### PR TITLE
Adding one-click deploy template to Render.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ https://github.com/abi/screenshot-to-code/assets/23818/3fec0f77-44e8-4fb3-a769-a
 🆕 [Try it here (paid)](https://screenshottocode.com). Or see [Getting Started](#-getting-started) for local install instructions to use with your own API keys.
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/abiraja)
+
+## One-Click Deployment (Third-Party)
+
+[![Deploy on Render.com](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/abi/screenshot-to-code)


### PR DESCRIPTION
Render has raised a total of $77.5 million in funding over 4 rounds. Do you need to research this company also? 

It seems like you're deciding not to approve these links because you would like to sell a cloud product while simultaneously engaging a community of open source developers. 

Open source projects are not designed to exploit OS developers for your personal gain selling a cloud product by making self-hosted installation more difficult.