### PR TITLE
Fix Python version in dockerfile to avoid TypeError

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.12.3-slim-bullseye
 
 ENV POETRY_VERSION 1.4.1
 


### PR DESCRIPTION
fix error:
TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'