### PR TITLE
Title: Fix Typo in README.md for GPT-4o

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supported stacks:
 Supported AI models:
 
 - Claude Sonnet 3.5 - Best model!
-- GPT-4O - also recommended!
+- GPT-4o - also recommended!
 - DALL-E 3 or Flux Schnell (using Replicate) for image generation
 
 See the [Examples](#-examples) section below for more demos.


### PR DESCRIPTION
 This pull request corrects a typo in the README.md file, changing "gpt 40" to "gpt 4o" to accurately reflect the project's way. This ensures clarity and consistency in the documentation, helping users understand the correct version of the model being referenced.