### PR TITLE
[#462] Fix: Update Dockerfile ENV format and Resolve Poetry virtualenv issue

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.12.3-slim-bullseye
 
-ENV POETRY_VERSION 1.4.1
+ENV POETRY_VERSION=1.4.1
 
 # Install system dependencies
-RUN pip install "poetry==$POETRY_VERSION"
+RUN python3 -m pip install "poetry==$POETRY_VERSION"
 
 # Set work directory
 WORKDIR /app

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12.3-slim-bullseye
 
-ENV POETRY_VERSION=1.4.1
+ENV POETRY_VERSION=1.7.1
 
 # Install system dependencies
 RUN python3 -m pip install "poetry==$POETRY_VERSION"

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1317,7 +1317,7 @@ cfgv = ">=2.0.0"
 identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
-virtualenv = ">=20.10.0, <=20.26.0"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "proglog"

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1317,7 +1317,7 @@ cfgv = ">=2.0.0"
 identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
-virtualenv = ">=20.10.0"
+virtualenv = ">=20.10.0, <=20.26.0"
 
 [[package]]
 name = "proglog"


### PR DESCRIPTION
1. Updated Dockerfile to use "ENV key=value" format instead of legacy "ENV key value" format (line 3) to address the LegacyKeyValueFormat warning.
2. Resolved an issue with Poetry's virtualenv version compatibility to ensure smooth environment setup and dependency management.