### PR TITLE
Update Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12.3-slim-bullseye
 
-ENV POETRY_VERSION 1.4.1
+ENV POETRY_VERSION 1.7.1
 
 # Install system dependencies
 RUN pip install "poetry==$POETRY_VERSION"


### PR DESCRIPTION
I encountered the following errors when the `POETRY_VRRSION` was set to `1.4.1`,
```
27.25   ImportError
27.25
27.25   cannot import name 'fs_path_id' from 'virtualenv.info' (/usr/local/lib/python3.12/site-packages/virtualenv/info.py)
27.25
27.25   at /usr/local/lib/python3.12/site-packages/virtualenv/discovery/builtin.py:10 in <module>
27.25         6│ from contextlib import suppress
27.25         7│ from pathlib import Path
27.25         8│ from typing import TYPE_CHECKING, Callable
27.25         9│
27.25     →  10│ from virtualenv.info import IS_WIN, fs_path_id
27.25        11│
27.25        12│ from .discover import Discover
27.25        13│ from .py_info import PythonInfo
27.25        14│ from .py_spec import PythonSpec
```
then I checked the `backend/poetry.lock` file, and it showed that the correct version is `1.7.1`, then I upgraded it, and it worked.