### PR TITLE
Add the `shell` install statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ cd backend
 echo "OPENAI_API_KEY=sk-your-key" > .env
 echo "ANTHROPIC_API_KEY=your-key" > .env
 poetry install
+poetry self add poetry-plugin-shell
 poetry shell
 poetry run uvicorn main:app --reload --port 7001
 ```


### PR DESCRIPTION
The shell command was moved to a plugin: [poetry-plugin-shell](https://github.com/python-poetry/poetry-plugin-shell)

Reference: https://python-poetry.org/docs/cli/#script-project