### PR TITLE
Refactor prompt structure

### DIFF
--- a/backend/prompts/types.py
+++ b/backend/prompts/types.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict
+from typing import Literal, TypedDict, List
 
 
 class SystemPrompts(TypedDict):
@@ -9,6 +9,13 @@ class SystemPrompts(TypedDict):
     ionic_tailwind: str
     vue_tailwind: str
     svg: str
+
+
+class PromptContent(TypedDict):
+    """Unified structure for prompt text and images."""
+
+    text: str
+    images: List[str]
 
 
 Stack = Literal[

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -198,17 +198,13 @@ function App() {
             ...baseCommitObject,
             type: "ai_create" as const,
             parentHash: null,
-            inputs: { image_url: referenceImages[0] },
+            inputs: params.prompt,
           }
         : {
             ...baseCommitObject,
             type: "ai_edit" as const,
             parentHash: head,
-            inputs: {
-              prompt: params.history
-                ? params.history[params.history.length - 1]
-                : "",
-            },
+            inputs: params.prompt,
           };
 
     // Create a new commit and set it as the head
@@ -258,8 +254,8 @@ function App() {
     if (referenceImages.length > 0) {
       doGenerateCode({
         generationType: "create",
-        image: referenceImages[0],
         inputMode,
+        prompt: { text: "", images: [referenceImages[0]] },
       });
     }
   }
@@ -273,7 +269,7 @@ function App() {
     doGenerateCode({
       generationType: "create",
       inputMode: "text",
-      image: text,
+      prompt: { text, images: [] },
     });
   }
 
@@ -314,12 +310,18 @@ function App() {
         selectedElement.outerHTML;
     }
 
-    const updatedHistory = [...historyTree, modifiedUpdateInstruction];
+    const updatedHistory = [
+      ...historyTree,
+      { text: modifiedUpdateInstruction, images: [] },
+    ];
 
     doGenerateCode({
       generationType: "update",
       inputMode,
-      image: inputMode === "text" ? initialPrompt : referenceImages[0],
+      prompt:
+        inputMode === "text"
+          ? { text: initialPrompt, images: [] }
+          : { text: "", images: [referenceImages[0]] },
       history: updatedHistory,
       isImportedFromCode,
     });

--- a/frontend/src/components/commits/types.ts
+++ b/frontend/src/components/commits/types.ts
@@ -19,18 +19,16 @@ export type BaseCommit = {
 
 export type CommitType = "ai_create" | "ai_edit" | "code_create";
 
+import { PromptContent } from "../../types";
+
 export type AiCreateCommit = BaseCommit & {
   type: "ai_create";
-  inputs: {
-    image_url: string;
-  };
+  inputs: PromptContent;
 };
 
 export type AiEditCommit = BaseCommit & {
   type: "ai_edit";
-  inputs: {
-    prompt: string;
-  };
+  inputs: PromptContent;
 };
 
 export type CodeCreateCommit = BaseCommit & {

--- a/frontend/src/components/history/utils.test.ts
+++ b/frontend/src/components/history/utils.test.ts
@@ -10,9 +10,7 @@ const basicLinearHistory: Record<CommitHash, Commit> = {
     parentHash: null,
     variants: [{ code: "<html>1. create</html>" }],
     selectedVariantIndex: 0,
-    inputs: {
-      image_url: "",
-    },
+    inputs: { text: "", images: [""] },
   },
   "1": {
     hash: "1",
@@ -22,9 +20,7 @@ const basicLinearHistory: Record<CommitHash, Commit> = {
     parentHash: "0",
     variants: [{ code: "<html>2. edit with better icons</html>" }],
     selectedVariantIndex: 0,
-    inputs: {
-      prompt: "use better icons",
-    },
+    inputs: { text: "use better icons", images: [] },
   },
   "2": {
     hash: "2",
@@ -34,9 +30,7 @@ const basicLinearHistory: Record<CommitHash, Commit> = {
     parentHash: "1",
     variants: [{ code: "<html>3. edit with better icons and red text</html>" }],
     selectedVariantIndex: 0,
-    inputs: {
-      prompt: "make text red",
-    },
+    inputs: { text: "make text red", images: [] },
   },
 };
 
@@ -66,9 +60,7 @@ const basicBranchingHistory: Record<CommitHash, Commit> = {
       { code: "<html>4. edit with better icons and green text</html>" },
     ],
     selectedVariantIndex: 0,
-    inputs: {
-      prompt: "make text green",
-    },
+    inputs: { text: "make text green", images: [] },
   },
 };
 
@@ -84,9 +76,7 @@ const longerBranchingHistory: Record<CommitHash, Commit> = {
       { code: "<html>5. edit with better icons and green, bold text</html>" },
     ],
     selectedVariantIndex: 0,
-    inputs: {
-      prompt: "make text bold",
-    },
+    inputs: { text: "make text bold", images: [] },
   },
 };
 
@@ -99,9 +89,7 @@ const basicBadHistory: Record<CommitHash, Commit> = {
     parentHash: null,
     variants: [{ code: "<html>1. create</html>" }],
     selectedVariantIndex: 0,
-    inputs: {
-      image_url: "",
-    },
+    inputs: { text: "", images: [""] },
   },
   "1": {
     hash: "1",
@@ -111,51 +99,52 @@ const basicBadHistory: Record<CommitHash, Commit> = {
     parentHash: "2", // <- Bad parent hash
     variants: [{ code: "<html>2. edit with better icons</html>" }],
     selectedVariantIndex: 0,
-    inputs: {
-      prompt: "use better icons",
-    },
+    inputs: { text: "use better icons", images: [] },
   },
 };
 
 describe("History Utils", () => {
   test("should correctly extract the history tree", () => {
     expect(extractHistory("2", basicLinearHistory)).toEqual([
-      "<html>1. create</html>",
-      "use better icons",
-      "<html>2. edit with better icons</html>",
-      "make text red",
-      "<html>3. edit with better icons and red text</html>",
+      { text: "<html>1. create</html>", images: [] },
+      { text: "use better icons", images: [] },
+      { text: "<html>2. edit with better icons</html>", images: [] },
+      { text: "make text red", images: [] },
+      { text: "<html>3. edit with better icons and red text</html>", images: [] },
     ]);
 
     expect(extractHistory("0", basicLinearHistory)).toEqual([
-      "<html>1. create</html>",
+      { text: "<html>1. create</html>", images: [] },
     ]);
 
     // Test branching
     expect(extractHistory("3", basicBranchingHistory)).toEqual([
-      "<html>1. create</html>",
-      "use better icons",
-      "<html>2. edit with better icons</html>",
-      "make text green",
-      "<html>4. edit with better icons and green text</html>",
+      { text: "<html>1. create</html>", images: [] },
+      { text: "use better icons", images: [] },
+      { text: "<html>2. edit with better icons</html>", images: [] },
+      { text: "make text green", images: [] },
+      { text: "<html>4. edit with better icons and green text</html>", images: [] },
     ]);
 
     expect(extractHistory("4", longerBranchingHistory)).toEqual([
-      "<html>1. create</html>",
-      "use better icons",
-      "<html>2. edit with better icons</html>",
-      "make text green",
-      "<html>4. edit with better icons and green text</html>",
-      "make text bold",
-      "<html>5. edit with better icons and green, bold text</html>",
+      { text: "<html>1. create</html>", images: [] },
+      { text: "use better icons", images: [] },
+      { text: "<html>2. edit with better icons</html>", images: [] },
+      { text: "make text green", images: [] },
+      { text: "<html>4. edit with better icons and green text</html>", images: [] },
+      { text: "make text bold", images: [] },
+      {
+        text: "<html>5. edit with better icons and green, bold text</html>",
+        images: [],
+      },
     ]);
 
     expect(extractHistory("2", longerBranchingHistory)).toEqual([
-      "<html>1. create</html>",
-      "use better icons",
-      "<html>2. edit with better icons</html>",
-      "make text red",
-      "<html>3. edit with better icons and red text</html>",
+      { text: "<html>1. create</html>", images: [] },
+      { text: "use better icons", images: [] },
+      { text: "<html>2. edit with better icons</html>", images: [] },
+      { text: "make text red", images: [] },
+      { text: "<html>3. edit with better icons and red text</html>", images: [] },
     ]);
 
     // Errors

--- a/frontend/src/components/history/utils.ts
+++ b/frontend/src/components/history/utils.ts
@@ -1,21 +1,25 @@
 import { Commit, CommitHash, CommitType } from "../commits/types";
+import { PromptContent } from "../../types";
 
 export function extractHistory(
   hash: CommitHash,
   commits: Record<CommitHash, Commit>
-): string[] {
-  const flatHistory: string[] = [];
+): PromptContent[] {
+  const flatHistory: PromptContent[] = [];
 
   let currentCommitHash: CommitHash | null = hash;
   while (currentCommitHash !== null) {
     const commit: Commit | null = commits[currentCommitHash];
 
     if (commit) {
-      flatHistory.unshift(commit.variants[commit.selectedVariantIndex].code);
+      flatHistory.unshift({
+        text: commit.variants[commit.selectedVariantIndex].code,
+        images: [],
+      });
 
       // For edits, add the prompt to the history
       if (commit.type === "ai_edit") {
-        flatHistory.unshift(commit.inputs.prompt);
+        flatHistory.unshift(commit.inputs);
       }
 
       // Move to the parent of the current item
@@ -65,7 +69,7 @@ export function summarizeHistoryItem(commit: Commit) {
     case "ai_create":
       return "Create";
     case "ai_edit":
-      return commit.inputs.prompt;
+      return commit.inputs.text;
     case "code_create":
       return "Imported from code";
     default: {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -31,11 +31,16 @@ export enum ScreenRecorderState {
   FINISHED = "finished",
 }
 
+export interface PromptContent {
+  text: string;
+  images: string[]; // Array of data URLs
+}
+
 export interface CodeGenerationParams {
   generationType: "create" | "update";
   inputMode: "image" | "video" | "text";
-  image: string;
-  history?: string[];
+  prompt: PromptContent;
+  history?: PromptContent[];
   isImportedFromCode?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- add `PromptContent` type in frontend and backend
- update commit and history logic to use `PromptContent`
- adapt prompt assembly for new structure

## Testing
- `poetry run pytest`
- `yarn test` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68499259733883329404de5d4b36230f