### PR TITLE
Redesign start pane input modes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,6 @@ import { GenerationSettings } from "./components/settings/GenerationSettings";
 import StartPane from "./components/start-pane/StartPane";
 import { Commit } from "./components/commits/types";
 import { createCommit } from "./components/commits/utils";
-import GenerateFromText from "./components/generate-from-text/GenerateFromText";
 
 function App() {
   const {
@@ -397,10 +396,6 @@ function App() {
 
           {IS_RUNNING_ON_CLOUD && !settings.openAiApiKey && <OnboardingNote />}
 
-          {appState === AppState.INITIAL && (
-            <GenerateFromText doCreateFromText={doCreateFromText} />
-          )}
-
           {/* Rest of the sidebar when we're not in the initial state */}
           {(appState === AppState.CODING ||
             appState === AppState.CODE_READY) && (
@@ -418,6 +413,7 @@ function App() {
         {appState === AppState.INITIAL && (
           <StartPane
             doCreate={doCreate}
+            doCreateFromText={doCreateFromText}
             importFromCode={importFromCode}
             settings={settings}
           />

--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -71,9 +71,14 @@ interface Props {
     textPrompt?: string
   ) => void;
   onUploadStateChange?: (hasUpload: boolean) => void;
+  dropzoneSize?: "large" | "compact";
 }
 
-function ImageUpload({ setReferenceImages, onUploadStateChange }: Props) {
+function ImageUpload({
+  setReferenceImages,
+  onUploadStateChange,
+  dropzoneSize = "large",
+}: Props) {
   const [files, setFiles] = useState<FileWithPreview[]>([]);
   const [uploadedDataUrls, setUploadedDataUrls] = useState<string[]>([]);
   const [uploadedInputMode, setUploadedInputMode] = useState<
@@ -188,15 +193,22 @@ function ImageUpload({ setReferenceImages, onUploadStateChange }: Props) {
     return () => files.forEach((file) => URL.revokeObjectURL(file.preview));
   }, [files]);
 
-  const style = useMemo(
-    () => ({
+  const style = useMemo(() => {
+    const sizeOverrides =
+      dropzoneSize === "compact"
+        ? {
+            width: "100%",
+            minHeight: "280px",
+          }
+        : {};
+    return {
       ...baseStyle,
+      ...sizeOverrides,
       ...(isFocused ? focusedStyle : {}),
       ...(isDragAccept ? acceptStyle : {}),
       ...(isDragReject ? rejectStyle : {}),
-    }),
-    [isFocused, isDragAccept, isDragReject]
-  );
+    };
+  }, [dropzoneSize, isFocused, isDragAccept, isDragReject]);
 
   // Screen recorder callback - wrap to include empty text prompt
   const handleScreenRecorderGenerate = (

--- a/frontend/src/components/UrlInputSection.tsx
+++ b/frontend/src/components/UrlInputSection.tsx
@@ -11,9 +11,14 @@ interface Props {
     inputMode: "image" | "video",
     textPrompt?: string
   ) => void;
+  label?: string;
 }
 
-export function UrlInputSection({ doCreate, screenshotOneApiKey }: Props) {
+export function UrlInputSection({
+  doCreate,
+  screenshotOneApiKey,
+  label = "Or screenshot a URL...",
+}: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const [referenceUrl, setReferenceUrl] = useState("");
 
@@ -64,7 +69,7 @@ export function UrlInputSection({ doCreate, screenshotOneApiKey }: Props) {
 
   return (
     <div className="max-w-[90%] min-w-[40%] gap-y-2 flex flex-col">
-      <div className="text-gray-500 text-sm">Or screenshot a URL...</div>
+      {label && <div className="text-gray-500 text-sm">{label}</div>}
       <Input
         placeholder="Enter URL"
         onChange={(e) => setReferenceUrl(e.target.value)}

--- a/frontend/src/components/generate-from-text/GenerateFromText.tsx
+++ b/frontend/src/components/generate-from-text/GenerateFromText.tsx
@@ -5,18 +5,27 @@ import toast from "react-hot-toast";
 
 interface GenerateFromTextProps {
   doCreateFromText: (text: string) => void;
+  defaultOpen?: boolean;
+  showTrigger?: boolean;
+  className?: string;
 }
 
-function GenerateFromText({ doCreateFromText }: GenerateFromTextProps) {
-  const [isOpen, setIsOpen] = useState(false);
+function GenerateFromText({
+  doCreateFromText,
+  defaultOpen = false,
+  showTrigger = true,
+  className,
+}: GenerateFromTextProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isOpenState = showTrigger ? isOpen : true;
 
   useEffect(() => {
-    if (isOpen && textareaRef.current) {
+    if (isOpenState && textareaRef.current) {
       textareaRef.current.focus();
     }
-  }, [isOpen]);
+  }, [isOpenState]);
 
   const handleGenerate = () => {
     if (text.trim() === "") {
@@ -34,8 +43,8 @@ function GenerateFromText({ doCreateFromText }: GenerateFromTextProps) {
   };
 
   return (
-    <div className="mt-4">
-      {!isOpen ? (
+    <div className={className}>
+      {showTrigger && !isOpenState ? (
         <div className="flex justify-center">
           <Button variant="secondary" onClick={() => setIsOpen(true)}>
             Generate from text prompt [BETA]
@@ -57,9 +66,11 @@ function GenerateFromText({ doCreateFromText }: GenerateFromTextProps) {
               Press Cmd/Ctrl + Enter to generate
             </span>
             <div className="flex gap-2">
-              <Button variant="outline" onClick={() => setIsOpen(false)}>
-                Cancel
-              </Button>
+              {showTrigger && (
+                <Button variant="outline" onClick={() => setIsOpen(false)}>
+                  Cancel
+                </Button>
+              )}
               <Button onClick={handleGenerate}>Generate</Button>
             </div>
           </div>

--- a/frontend/src/components/start-pane/StartPane.tsx
+++ b/frontend/src/components/start-pane/StartPane.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React from "react";
 import ImageUpload from "../ImageUpload";
 import { UrlInputSection } from "../UrlInputSection";
 import ImportCodeSection from "../ImportCodeSection";
 import { Settings } from "../../types";
 import { Stack } from "../../lib/stacks";
+import GenerateFromText from "../generate-from-text/GenerateFromText";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 
 interface Props {
   doCreate: (
@@ -11,28 +13,109 @@ interface Props {
     inputMode: "image" | "video",
     textPrompt?: string
   ) => void;
+  doCreateFromText: (text: string) => void;
   importFromCode: (code: string, stack: Stack) => void;
   settings: Settings;
 }
 
-const StartPane: React.FC<Props> = ({ doCreate, importFromCode, settings }) => {
-  const [hasImageUpload, setHasImageUpload] = useState(false);
-
+const StartPane: React.FC<Props> = ({
+  doCreate,
+  doCreateFromText,
+  importFromCode,
+  settings,
+}) => {
   return (
-    <div className="flex flex-col justify-center items-center gap-y-10">
-      <ImageUpload
-        setReferenceImages={doCreate}
-        onUploadStateChange={setHasImageUpload}
-      />
-      {!hasImageUpload && (
-        <>
-          <UrlInputSection
-            doCreate={doCreate}
-            screenshotOneApiKey={settings.screenshotOneApiKey}
-          />
-          <ImportCodeSection importFromCode={importFromCode} />
-        </>
-      )}
+    <div className="flex flex-col items-center justify-center py-12">
+      <div className="w-full max-w-5xl px-6">
+        <div className="text-center mb-8">
+          <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">
+            Start from anything
+          </h2>
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            Upload a screenshot, capture a URL, describe it in text, or import
+            existing code to jump straight into iteration.
+          </p>
+        </div>
+
+        <Tabs defaultValue="image" className="w-full">
+          <TabsList className="grid w-full grid-cols-2 gap-2 md:grid-cols-4">
+            <TabsTrigger value="image">Image / Video</TabsTrigger>
+            <TabsTrigger value="url">URL</TabsTrigger>
+            <TabsTrigger value="text">Text Prompt</TabsTrigger>
+            <TabsTrigger value="import">Import Code</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="image">
+            <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-zinc-950">
+              <div className="mb-4">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                  Generate from an image or video
+                </h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Drop a screenshot or screen recording to recreate the UI in
+                  code.
+                </p>
+              </div>
+              <ImageUpload
+                setReferenceImages={doCreate}
+                dropzoneSize="compact"
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="url">
+            <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-zinc-950">
+              <div className="mb-4">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                  Capture a URL
+                </h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Generate from a live site by taking a snapshot first.
+                </p>
+              </div>
+              <UrlInputSection
+                doCreate={doCreate}
+                screenshotOneApiKey={settings.screenshotOneApiKey}
+                label="Enter a URL to capture."
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="text">
+            <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-zinc-950">
+              <div className="mb-4">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                  Generate from a text prompt
+                </h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Describe the UI you want, and we&apos;ll build the first
+                  version.
+                </p>
+              </div>
+              <GenerateFromText
+                doCreateFromText={doCreateFromText}
+                defaultOpen
+                showTrigger={false}
+                className="mt-0"
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="import">
+            <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-zinc-950">
+              <div className="mb-4">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                  Import existing code
+                </h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Paste HTML/CSS to start iterating on an existing project.
+                </p>
+              </div>
+              <ImportCodeSection importFromCode={importFromCode} />
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Provide a single, cleaner entry point that supports all input types (image/video, URL, text prompt, and importing code) so users can start generation from any source without scattered UI flows.
- Surface the text-prompt flow inline in the new layout and make dropzone and URL labeling configurable to better fit multiple layouts and screen sizes.

### Description
- Replaced the old initial-state UI with a tabbed `StartPane` that exposes four flows: Image/Video, URL, Text Prompt, and Import Code, using the existing `Tabs` primitives and updated layout/copy (`frontend/src/components/start-pane/StartPane.tsx`).
- Extended `GenerateFromText` with props `defaultOpen`, `showTrigger`, and `className` to allow inline rendering without the trigger button (`frontend/src/components/generate-from-text/GenerateFromText.tsx`).
- Added `dropzoneSize` to `ImageUpload` to support a compact dropzone variant and adjusted the dropzone style accordingly (`frontend/src/components/ImageUpload.tsx`).
- Made the URL section label configurable via a `label` prop in `UrlInputSection` so it fits the new layout (`frontend/src/components/UrlInputSection.tsx`).
- Hooked the new `doCreateFromText` prop through `App.tsx` so the text-prompt flow triggers generation from the main app (`frontend/src/App.tsx`).

### Testing
- Started the frontend dev server with `yarn --cwd frontend dev --host 0.0.0.0 --port 4173` which reported Vite ready and served the app successfully. (success)
- Ran a Playwright script that navigated to the local dev server and captured a screenshot of the new start pane at `artifacts/start-pane.png`. (success)
- Verified TypeScript output which reported `Found 0 errors` while watching files. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce726ac1483329fb191628611f0c4)