### PR TITLE
Add Flutter stack with DartPad previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Supported stacks:
 - Vue + Tailwind
 - Bootstrap
 - Ionic + Tailwind
+- Flutter
 - SVG
 
 Supported AI models:
@@ -116,5 +117,4 @@ https://github.com/user-attachments/assets/a335a105-f9cc-40e6-ac6b-64e5390bfc21
 
 
 https://github.com/user-attachments/assets/205cb5c7-9c3c-438d-acd4-26dfe6e077e5
-
 

--- a/backend/prompts/imported_code_prompts.py
+++ b/backend/prompts/imported_code_prompts.py
@@ -130,6 +130,20 @@ Return only the full code in <html></html> tags.
 Do not include markdown "```" or "```html" at the start or end.
 The return result must only include the code."""
 
+IMPORTED_CODE_FLUTTER_SYSTEM_PROMPT = """
+You are an expert Flutter developer.
+
+- Do not add placeholder comments in place of full code. WRITE THE FULL CODE.
+- Repeat elements as needed to match the design.
+- For images, use placeholder images from https://placehold.co and include a detailed description of the image in the alt text equivalent (e.g. in comments near the Image.network).
+
+Use Flutter's standard widgets (e.g. MaterialApp, Scaffold, Container, Row, Column, Stack, Text, Image).
+Return a complete, runnable Dart file (main.dart) that can run on Flutter web.
+
+Return only the full Dart code.
+Do not include markdown "```" or "```dart" at the start or end.
+"""
+
 IMPORTED_CODE_SVG_SYSTEM_PROMPT = """
 You are an expert at building SVGs.
 
@@ -149,5 +163,6 @@ IMPORTED_CODE_SYSTEM_PROMPTS = SystemPrompts(
     bootstrap=IMPORTED_CODE_BOOTSTRAP_SYSTEM_PROMPT,
     ionic_tailwind=IMPORTED_CODE_IONIC_TAILWIND_SYSTEM_PROMPT,
     vue_tailwind=IMPORTED_CODE_VUE_TAILWIND_SYSTEM_PROMPT,
+    flutter=IMPORTED_CODE_FLUTTER_SYSTEM_PROMPT,
     svg=IMPORTED_CODE_SVG_SYSTEM_PROMPT,
 )

--- a/backend/prompts/screenshot_system_prompts.py
+++ b/backend/prompts/screenshot_system_prompts.py
@@ -168,6 +168,25 @@ Do not include markdown "```" or "```html" at the start or end.
 The return result must only include the code.
 """
 
+FLUTTER_SYSTEM_PROMPT = """
+You are an expert Flutter developer.
+You take screenshots of a reference UI from the user, and then build a Flutter app
+that visually matches the screenshot.
+
+- Make sure the app looks exactly like the screenshot.
+- Pay close attention to background color, text color, font size, font family,
+padding, margin, border, etc. Match the colors and sizes exactly.
+- Use the exact text from the screenshot.
+- Do not add placeholder comments in place of full code. WRITE THE FULL CODE.
+- Repeat elements as needed to match the screenshot. For example, if there are 15 items, the code should have 15 items.
+- For images, use placeholder images from https://placehold.co and include a detailed description of the image in the alt text equivalent (e.g. in comments near the Image.network).
+
+Use Flutter's standard widgets (e.g. MaterialApp, Scaffold, Container, Row, Column, Stack, Text, Image).
+Return a complete, runnable Dart file (main.dart) that can run on Flutter web.
+
+Return only the full Dart code.
+Do not include markdown "```" or "```dart" at the start or end.
+"""
 
 SVG_SYSTEM_PROMPT = """
 You are an expert at building SVGs.
@@ -194,5 +213,6 @@ SYSTEM_PROMPTS = SystemPrompts(
     bootstrap=BOOTSTRAP_SYSTEM_PROMPT,
     ionic_tailwind=IONIC_TAILWIND_SYSTEM_PROMPT,
     vue_tailwind=VUE_TAILWIND_SYSTEM_PROMPT,
+    flutter=FLUTTER_SYSTEM_PROMPT,
     svg=SVG_SYSTEM_PROMPT,
 )

--- a/backend/prompts/text_prompts.py
+++ b/backend/prompts/text_prompts.py
@@ -105,6 +105,20 @@ In terms of libraries,
 {FORMAT_INSTRUCTIONS}
 """
 
+FLUTTER_SYSTEM_PROMPT = """
+You are an expert Flutter developer.
+Create a Flutter UI based on the user's text prompt.
+
+- Make sure the UI matches the requested layout and details.
+- Use Flutter's standard widgets (e.g. MaterialApp, Scaffold, Container, Row, Column, Stack, Text, Image).
+- For images, use placeholder images from https://placehold.co and include a detailed description of the image in the alt text equivalent (e.g. in comments near the Image.network).
+
+Return a complete, runnable Dart file (main.dart) that can run on Flutter web.
+
+Return only the full Dart code.
+Do not include markdown "```" or "```dart" at the start or end.
+"""
+
 SVG_SYSTEM_PROMPT = f"""
 You are an expert at building SVGs.
 
@@ -122,5 +136,6 @@ SYSTEM_PROMPTS = SystemPrompts(
     bootstrap=BOOTSTRAP_SYSTEM_PROMPT,
     ionic_tailwind=IONIC_TAILWIND_SYSTEM_PROMPT,
     vue_tailwind=VUE_TAILWIND_SYSTEM_PROMPT,
+    flutter=FLUTTER_SYSTEM_PROMPT,
     svg=SVG_SYSTEM_PROMPT,
 )

--- a/backend/prompts/types.py
+++ b/backend/prompts/types.py
@@ -8,6 +8,7 @@ class SystemPrompts(TypedDict):
     bootstrap: str
     ionic_tailwind: str
     vue_tailwind: str
+    flutter: str
     svg: str
 
 
@@ -25,5 +26,6 @@ Stack = Literal[
     "bootstrap",
     "ionic_tailwind",
     "vue_tailwind",
+    "flutter",
     "svg",
 ]

--- a/frontend/src/components/preview/CodeTab.tsx
+++ b/frontend/src/components/preview/CodeTab.tsx
@@ -5,6 +5,7 @@ import { Settings } from "../../types";
 import copy from "copy-to-clipboard";
 import { useCallback } from "react";
 import toast from "react-hot-toast";
+import { Stack } from "../../lib/stacks";
 
 interface Props {
   code: string;
@@ -12,11 +13,16 @@ interface Props {
   settings: Settings;
 }
 
+const DARTPAD_ORIGIN = "https://dartpad.dev";
+const DARTPAD_EMBED_URL =
+  "https://dartpad.dev/embed-flutter.html?split=0&run=true&theme=dark";
+
 function CodeTab({ code, setCode, settings }: Props) {
   const copyCode = useCallback(() => {
     copy(code);
     toast.success("Copied to clipboard");
   }, [code]);
+  const isFlutter = settings.generatedCodeConfig === Stack.FLUTTER;
 
   const doOpenInCodepenio = useCallback(async () => {
     // TODO: Update CSS and JS external links depending on the framework being used
@@ -53,6 +59,21 @@ function CodeTab({ code, setCode, settings }: Props) {
     form.submit();
   }, [code]);
 
+  const doOpenInDartPad = useCallback(() => {
+    const dartPadWindow = window.open(DARTPAD_EMBED_URL, "_blank");
+    if (!dartPadWindow) return;
+    setTimeout(() => {
+      dartPadWindow.postMessage(
+        {
+          type: "sourceCode",
+          sourceCode: code,
+        },
+        DARTPAD_ORIGIN
+      );
+      dartPadWindow.postMessage({ type: "execute" }, DARTPAD_ORIGIN);
+    }, 1000);
+  }, [code]);
+
   return (
     <div className="relative">
       <div className="flex justify-start items-center px-4 mb-2">
@@ -64,18 +85,28 @@ function CodeTab({ code, setCode, settings }: Props) {
         >
           Copy Code <FaCopy className="ml-2" />
         </span>
-        <Button
-          onClick={doOpenInCodepenio}
-          className="bg-gray-100 text-black ml-2 py-2 px-4 border border-black rounded-md hover:bg-gray-400 focus:outline-none"
-          data-testid="open-codepen"
-        >
-          Open in{" "}
-          <img
-            src="https://assets.codepen.io/t-1/codepen-logo.svg"
-            alt="codepen.io"
-            className="h-4 ml-1"
-          />
-        </Button>
+        {isFlutter ? (
+          <Button
+            onClick={doOpenInDartPad}
+            className="bg-gray-100 text-black ml-2 py-2 px-4 border border-black rounded-md hover:bg-gray-400 focus:outline-none"
+            data-testid="open-dartpad"
+          >
+            Open in DartPad
+          </Button>
+        ) : (
+          <Button
+            onClick={doOpenInCodepenio}
+            className="bg-gray-100 text-black ml-2 py-2 px-4 border border-black rounded-md hover:bg-gray-400 focus:outline-none"
+            data-testid="open-codepen"
+          >
+            Open in{" "}
+            <img
+              src="https://assets.codepen.io/t-1/codepen-logo.svg"
+              alt="codepen.io"
+              className="h-4 ml-1"
+            />
+          </Button>
+        )}
       </div>
       <CodeMirror
         code={code}

--- a/frontend/src/components/preview/PreviewPane.tsx
+++ b/frontend/src/components/preview/PreviewPane.tsx
@@ -15,8 +15,28 @@ import { useProjectStore } from "../../store/project-store";
 import { extractHtml } from "./extractHtml";
 import PreviewComponent from "./PreviewComponent";
 import { downloadCode } from "./download";
+import { Stack } from "../../lib/stacks";
 
-function openInNewTab(code: string) {
+const DARTPAD_ORIGIN = "https://dartpad.dev";
+const DARTPAD_EMBED_URL =
+  "https://dartpad.dev/embed-flutter.html?split=0&run=true&theme=dark";
+
+function openInNewTab(code: string, stack: Stack) {
+  if (stack === Stack.FLUTTER) {
+    const dartPadWindow = window.open(DARTPAD_EMBED_URL, "_blank");
+    if (!dartPadWindow) return;
+    setTimeout(() => {
+      dartPadWindow.postMessage(
+        {
+          type: "sourceCode",
+          sourceCode: code,
+        },
+        DARTPAD_ORIGIN
+      );
+      dartPadWindow.postMessage({ type: "execute" }, DARTPAD_ORIGIN);
+    }, 1000);
+    return;
+  }
   const newWindow = window.open("", "_blank");
   if (newWindow) {
     newWindow.document.open();
@@ -83,7 +103,7 @@ function PreviewPane({ doUpdate, reset, settings }: Props) {
               </TabsTrigger>
             </TabsList>
             <Button
-              onClick={() => openInNewTab(previewCode)}
+              onClick={() => openInNewTab(previewCode, settings.generatedCodeConfig)}
               variant="ghost"
               size="icon"
               title="Open in New Tab"
@@ -114,6 +134,7 @@ function PreviewPane({ doUpdate, reset, settings }: Props) {
             code={previewCode}
             device="desktop"
             doUpdate={doUpdate}
+            stack={settings.generatedCodeConfig}
           />
         </TabsContent>
         <TabsContent value="mobile">
@@ -121,6 +142,7 @@ function PreviewPane({ doUpdate, reset, settings }: Props) {
             code={previewCode}
             device="mobile"
             doUpdate={doUpdate}
+            stack={settings.generatedCodeConfig}
           />
         </TabsContent>
         <TabsContent value="code">

--- a/frontend/src/lib/stacks.ts
+++ b/frontend/src/lib/stacks.ts
@@ -7,6 +7,7 @@ export enum Stack {
   BOOTSTRAP = "bootstrap",
   VUE_TAILWIND = "vue_tailwind",
   IONIC_TAILWIND = "ionic_tailwind",
+  FLUTTER = "flutter",
   SVG = "svg",
 }
 
@@ -19,5 +20,6 @@ export const STACK_DESCRIPTIONS: {
   bootstrap: { components: ["Bootstrap"], inBeta: false },
   vue_tailwind: { components: ["Vue", "Tailwind"], inBeta: true },
   ionic_tailwind: { components: ["Ionic", "Tailwind"], inBeta: true },
+  flutter: { components: ["Flutter"], inBeta: true },
   svg: { components: ["SVG"], inBeta: true },
 };


### PR DESCRIPTION
### Motivation
- Add first-class support for Flutter so the app can generate Flutter/Dart UI code from screenshots or text prompts and preview/run it in-browser.  
- Provide a DartPad-based runtime so generated Flutter code can be executed and inspected without requiring a local Flutter toolchain.  
- Expose an "Open in DartPad" action from the code view to improve the developer workflow for Flutter output.

### Description
- Add `flutter` to the backend `SystemPrompts` and provide Flutter-focused prompts in `backend/prompts/types.py`, `backend/prompts/screenshot_system_prompts.py`, `backend/prompts/text_prompts.py`, and `backend/prompts/imported_code_prompts.py`.  
- Register `FLUTTER` in the frontend stack registry and descriptions in `frontend/src/lib/stacks.ts`.  
- Implement DartPad-powered preview support in `frontend/src/components/preview/PreviewComponent.tsx` by embedding `https://dartpad.dev/embed-flutter.html`, posting `sourceCode` and `execute` messages to the DartPad iframe, and disabling the select/edit popup for Flutter previews.  
- Add DartPad open action and UI in `frontend/src/components/preview/CodeTab.tsx` and wire `openInNewTab` in `frontend/src/components/preview/PreviewPane.tsx` to send Flutter code to DartPad when the selected stack is `FLUTTER`.  
- Document Flutter as a supported stack in `README.md`.

### Testing
- Started the frontend dev server with `yarn --cwd frontend dev --host 0.0.0.0 --port 5173` and received a Vite-ready message indicating the app served locally.  
- TypeScript/Dev watch ran and reported `Found 0 errors` during the dev server run.  
- Attempted an automated UI check with Playwright to select the Flutter stack and capture a screenshot, but the Chromium instance crashed with a `SIGSEGV` during launch so the Playwright test failed; no DartPad runtime end-to-end screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836bfe70288332bc86302dfcf33160)