### PR TITLE
Fix variant flash on edits by initializing correct count

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -202,10 +202,12 @@ function App() {
     // Merge settings with params
     const updatedParams = { ...requestParams, ...settings };
 
-    // Create variants dynamically - start with 4 to handle most cases
-    // Backend will use however many it needs (typically 3)
+    // Use 4 variants for create, 2 for edits to match backend counts
+    // and avoid a flash when the backend sends the actual variant count
+    const initialVariantCount =
+      requestParams.generationType === "create" ? 4 : 2;
     const baseCommitObject = {
-      variants: Array(4)
+      variants: Array(initialVariantCount)
         .fill(null)
         .map(() => ({
           code: "",


### PR DESCRIPTION
When starting an edit, the frontend was always creating 4 variant slots
before the backend would send a message to resize to 2. This caused a
brief visible flash of 4 variants shrinking to 2. Now the initial variant
count matches the backend: 4 for creates, 2 for edits.

https://claude.ai/code/session_01Jy5ZaDzZw3NzLHUxpHRoQV