### PR TITLE
Add --port CLI flag to backend startup script

### DIFF
--- a/backend/start.py
+++ b/backend/start.py
@@ -1,4 +1,9 @@
+import argparse
+
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", port=7001, reload=True)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=7001)
+    args = parser.parse_args()
+    uvicorn.run("main:app", port=args.port, reload=True)


### PR DESCRIPTION
## Summary
Allow users to specify a custom port when starting the backend server via `python start.py --port <PORT>`. Defaults to 7001 if not specified.

## Test plan
- Run `python start.py --port 8000` and verify the server starts on port 8000
- Run `python start.py` and verify it defaults to port 7001

🤖 Generated with [Claude Code](https://claude.com/claude-code)