### PR TITLE
Add z-image-turbo as default Replicate model

### DIFF
--- a/backend/image_generation/generation.py
+++ b/backend/image_generation/generation.py
@@ -4,10 +4,15 @@ from typing import List, Literal, Union
 
 from openai import AsyncOpenAI
 
-from image_generation.replicate import call_replicate
+from image_generation.replicate import (
+    DEFAULT_IMAGE_MODEL,
+    ReplicateImageModel,
+    call_replicate,
+)
 
 
 REPLICATE_BATCH_SIZE = 20
+REPLICATE_IMAGE_MODEL: ReplicateImageModel = DEFAULT_IMAGE_MODEL
 
 
 async def process_tasks(
@@ -17,11 +22,11 @@ async def process_tasks(
     model: Literal["dalle3", "flux"],
 ) -> List[Union[str, None]]:
     start_time = time.time()
+    results: list[str | BaseException | None] = []
     if model == "dalle3":
         tasks = [generate_image_dalle(prompt, api_key, base_url) for prompt in prompts]
         results = await asyncio.gather(*tasks, return_exceptions=True)
     else:
-        results: list[str | BaseException] = []
         for i in range(0, len(prompts), REPLICATE_BATCH_SIZE):
             batch = prompts[i : i + REPLICATE_BATCH_SIZE]
             tasks = [generate_image_replicate(p, api_key) for p in batch]
@@ -60,12 +65,27 @@ async def generate_image_dalle(
 
 
 async def generate_image_replicate(prompt: str, api_key: str) -> str:
-    # We use Flux 2 Klein
-    return await call_replicate(
-        {
+    replicate_input: dict[str, str | int | float | bool]
+    if REPLICATE_IMAGE_MODEL == "flux_2_klein":
+        replicate_input = {
             "prompt": prompt,
             "aspect_ratio": "1:1",
             "output_format": "png",
-        },
+        }
+    else:
+        # Default to z-image-turbo with a square output.
+        replicate_input = {
+            "prompt": prompt,
+            "width": 1024,
+            "height": 1024,
+            "go_fast": False,
+            "output_format": "png",
+            "guidance_scale": 0,
+            "num_inference_steps": 8,
+        }
+
+    return await call_replicate(
+        replicate_input,
         api_key,
+        model=REPLICATE_IMAGE_MODEL,
     )

--- a/backend/image_generation/replicate.py
+++ b/backend/image_generation/replicate.py
@@ -1,10 +1,17 @@
 import asyncio
 import httpx
-from typing import Any, Mapping, cast
+from typing import Any, Literal, Mapping, cast
 
 
 REPLICATE_API_BASE_URL = "https://api.replicate.com/v1"
-FLUX_MODEL_PATH = "black-forest-labs/flux-2-klein-4b"
+ReplicateImageModel = Literal["z_image_turbo", "flux_2_klein"]
+Z_IMAGE_TURBO_MODEL_PATH = "prunaai/z-image-turbo"
+FLUX_2_KLEIN_MODEL_PATH = "black-forest-labs/flux-2-klein-4b"
+MODEL_PATHS: dict[ReplicateImageModel, str] = {
+    "z_image_turbo": Z_IMAGE_TURBO_MODEL_PATH,
+    "flux_2_klein": FLUX_2_KLEIN_MODEL_PATH,
+}
+DEFAULT_IMAGE_MODEL: ReplicateImageModel = "z_image_turbo"
 REMOVE_BACKGROUND_VERSION = (
     "a029dff38972b5fda4ec5d75d7d1cd25aeff621d2cf4946a41055d7db66b80bc"
 )
@@ -90,7 +97,7 @@ def _extract_output_url(result: Any, context: str) -> str:
             return url
 
     if isinstance(result, list) and len(result) > 0:
-        first: Any = result[0]
+        first = cast(Any, result[0])
         if isinstance(first, str) and first:
             return first
         if isinstance(first, Mapping):
@@ -136,6 +143,11 @@ async def remove_background(image_url: str, api_token: str) -> str:
     return _extract_output_url(result, "background remover")
 
 
-async def call_replicate(input: dict[str, str | int], api_token: str) -> str:
-    result = await call_replicate_model(FLUX_MODEL_PATH, input, api_token)
-    return _extract_output_url(result, "Flux prediction")
+async def call_replicate(
+    input: dict[str, str | int | float | bool],
+    api_token: str,
+    model: ReplicateImageModel = DEFAULT_IMAGE_MODEL,
+) -> str:
+    model_path = MODEL_PATHS[model]
+    result = await call_replicate_model(model_path, input, api_token)
+    return _extract_output_url(result, f"Replicate image model prediction ({model})")

--- a/backend/tests/test_batching.py
+++ b/backend/tests/test_batching.py
@@ -71,3 +71,65 @@ async def test_remove_background_batches_calls(
     assert len(result.result["images"]) == 25
     assert all(r["status"] == "ok" for r in result.result["images"])
     assert max_concurrent <= 20
+
+
+@pytest.mark.asyncio
+async def test_generate_image_replicate_uses_square_z_image_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_call_replicate(
+        input: dict[str, object], api_key: str, model: str
+    ) -> str:
+        captured["input"] = input
+        captured["api_key"] = api_key
+        captured["model"] = model
+        return "https://example.com/generated.jpg"
+
+    monkeypatch.setattr(generation, "call_replicate", fake_call_replicate)
+    monkeypatch.setattr(generation, "REPLICATE_IMAGE_MODEL", "z_image_turbo")
+
+    result = await generation.generate_image_replicate("test prompt", "replicate-key")
+
+    assert result == "https://example.com/generated.jpg"
+    assert captured["api_key"] == "replicate-key"
+    assert captured["model"] == "z_image_turbo"
+    assert captured["input"] == {
+        "prompt": "test prompt",
+        "width": 1024,
+        "height": 1024,
+        "go_fast": False,
+        "output_format": "png",
+        "guidance_scale": 0,
+        "num_inference_steps": 8,
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_image_replicate_uses_flux_payload_when_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_call_replicate(
+        input: dict[str, object], api_key: str, model: str
+    ) -> str:
+        captured["input"] = input
+        captured["api_key"] = api_key
+        captured["model"] = model
+        return "https://example.com/generated.png"
+
+    monkeypatch.setattr(generation, "call_replicate", fake_call_replicate)
+    monkeypatch.setattr(generation, "REPLICATE_IMAGE_MODEL", "flux_2_klein")
+
+    result = await generation.generate_image_replicate("flux prompt", "replicate-key")
+
+    assert result == "https://example.com/generated.png"
+    assert captured["api_key"] == "replicate-key"
+    assert captured["model"] == "flux_2_klein"
+    assert captured["input"] == {
+        "prompt": "flux prompt",
+        "aspect_ratio": "1:1",
+        "output_format": "png",
+    }

--- a/backend/tests/test_image_generation_replicate.py
+++ b/backend/tests/test_image_generation_replicate.py
@@ -39,7 +39,9 @@ def test_extract_output_url_invalid_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_call_replicate_uses_flux_model(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_call_replicate_uses_default_image_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, object] = {}
 
     async def fake_call_replicate_model(
@@ -55,7 +57,34 @@ async def test_call_replicate_uses_flux_model(monkeypatch: pytest.MonkeyPatch) -
     result = await replicate.call_replicate({"prompt": "test", "seed": 1}, "token-123")
 
     assert result == "https://example.com/flux.png"
-    assert captured["model_path"] == replicate.FLUX_MODEL_PATH
+    assert captured["model_path"] == replicate.MODEL_PATHS[replicate.DEFAULT_IMAGE_MODEL]
+    assert captured["api_token"] == "token-123"
+
+
+@pytest.mark.asyncio
+async def test_call_replicate_can_use_flux_2_klein(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_call_replicate_model(
+        model_path: str, input: dict[str, object], api_token: str
+    ) -> list[str]:
+        captured["model_path"] = model_path
+        captured["input"] = input
+        captured["api_token"] = api_token
+        return ["https://example.com/flux.png"]
+
+    monkeypatch.setattr(replicate, "call_replicate_model", fake_call_replicate_model)
+
+    result = await replicate.call_replicate(
+        {"prompt": "test", "seed": 1},
+        "token-123",
+        model="flux_2_klein",
+    )
+
+    assert result == "https://example.com/flux.png"
+    assert captured["model_path"] == replicate.FLUX_2_KLEIN_MODEL_PATH
     assert captured["api_token"] == "token-123"
 
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded Flux 2 Klein model with a configurable model selection system. Introduces z-image-turbo as the new default model with 1024×1024 square output, while keeping Flux 2 Klein available as an alternative. The implementation adds a `ReplicateImageModel` type, model path mapping, and comprehensive test coverage for both models.

## Test Plan

- All existing tests pass (pytest: 68 tests)
- All type checks pass (pyright: 0 errors, 0 warnings)
- New tests verify both z-image-turbo and Flux 2 Klein payloads
- Model selection via module-level constant is testable via monkeypatching

🤖 Generated with [Claude Code](https://claude.com/claude-code)