### PR TITLE
Add annotation tool to highlight changed elements in preview

### DIFF
--- a/backend/agent/tools/definitions.py
+++ b/backend/agent/tools/definitions.py
@@ -110,16 +110,16 @@ def _annotate_schema() -> Dict[str, Any]:
                 "items": {
                     "type": "object",
                     "properties": {
-                        "label": {
+                        "selector": {
                             "type": "string",
-                            "description": "Short label identifying the changed element (e.g. 'Header', 'Login button', 'Hero image').",
+                            "description": "CSS selector that uniquely identifies the changed element in the HTML (e.g. '#hero-section', '.navbar', 'button.login-btn', 'header > nav').",
                         },
                         "description": {
                             "type": "string",
                             "description": "One-sentence description of what was changed.",
                         },
                     },
-                    "required": ["label", "description"],
+                    "required": ["selector", "description"],
                 },
             }
         },
@@ -181,11 +181,12 @@ def canonical_tool_definitions(
             CanonicalToolDefinition(
                 name="annotate",
                 description=(
-                    "Annotate the changed elements to highlight what was modified. "
+                    "Annotate the changed elements to highlight them in the preview. "
                     "Call this tool exactly once, AFTER all code edits are complete "
                     "and right before returning your final response to the user. "
-                    "Each annotation should identify a changed element and include "
-                    "a short one-sentence description of what changed."
+                    "Each annotation requires a CSS selector that uniquely targets "
+                    "the changed element in the HTML, plus a short one-sentence "
+                    "description of what changed."
                 ),
                 parameters=_annotate_schema(),
             ),

--- a/backend/agent/tools/runtime.py
+++ b/backend/agent/tools/runtime.py
@@ -370,10 +370,10 @@ class AgentToolRuntime:
 
         cleaned: List[Dict[str, str]] = []
         for annotation in annotations:
-            label = ensure_str(annotation.get("label"))
+            selector = ensure_str(annotation.get("selector"))
             description = ensure_str(annotation.get("description"))
-            if label and description:
-                cleaned.append({"label": label, "description": description})
+            if selector and description:
+                cleaned.append({"selector": selector, "description": description})
 
         if not cleaned:
             return ToolExecutionResult(

--- a/backend/agent/tools/summaries.py
+++ b/backend/agent/tools/summaries.py
@@ -76,7 +76,7 @@ def summarize_tool_input(tool_call: ToolCall, file_state: AgentFileState) -> Dic
                 "count": len(annotations),
                 "annotations": [
                     {
-                        "label": ensure_str(a.get("label")),
+                        "selector": ensure_str(a.get("selector")),
                         "description": summarize_text(
                             ensure_str(a.get("description")), 160
                         ),

--- a/backend/prompts/system_prompt.py
+++ b/backend/prompts/system_prompt.py
@@ -18,7 +18,7 @@ You are a coding agent that's an expert at building front-ends.
 - When available, use generate_images to create image URLs from prompts (you may pass multiple prompts). The image generation AI is not capable of generating images with a transparent background.
 - Use remove_background to remove backgrounds from provided image URLs when needed (you may pass multiple image URLs).
 - Use retrieve_option to fetch the full HTML for a specific option (1-based option_number) when a user references another option.
-- After ALL code edits are complete and right before returning your final response, call annotate exactly once to highlight the elements you changed. Each annotation should have a short label identifying the element and a one-sentence description of what was changed. This helps the user quickly see what was modified.
+- After ALL code edits are complete and right before returning your final response, call annotate exactly once to highlight the elements you changed in the preview. Each annotation needs a CSS selector that uniquely targets the changed element in the HTML (e.g. '#hero-section', '.navbar', 'button.login-btn') and a one-sentence description of what was changed.
 
 
 # Stack-specific instructions

--- a/frontend/src/components/agent/AgentActivity.tsx
+++ b/frontend/src/components/agent/AgentActivity.tsx
@@ -358,19 +358,19 @@ function renderToolDetails(event: AgentEvent, variantCode?: string) {
         <div className="space-y-1.5">
           {(() => {
             const annotations =
-              (output?.annotations as Array<{ label: string; description: string }>) ||
-              (input?.annotations as Array<{ label: string; description: string }>) ||
+              (output?.annotations as Array<{ selector: string; description: string }>) ||
+              (input?.annotations as Array<{ selector: string; description: string }>) ||
               [];
             return annotations.map((annotation, index) => (
               <div
-                key={`${annotation.label}-${index}`}
+                key={`${annotation.selector}-${index}`}
                 className="flex items-start gap-2 rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-2"
               >
                 <BsTag className="text-amber-500 mt-0.5 shrink-0" />
                 <div>
-                  <span className="text-xs font-medium text-amber-700 dark:text-amber-300">
-                    {annotation.label}
-                  </span>
+                  <code className="text-xs font-mono text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/40 px-1 rounded">
+                    {annotation.selector}
+                  </code>
                   <span className="text-xs text-gray-600 dark:text-gray-400 ml-1.5">
                     {annotation.description}
                   </span>

--- a/frontend/src/components/preview/PreviewComponent.tsx
+++ b/frontend/src/components/preview/PreviewComponent.tsx
@@ -4,11 +4,17 @@ import useThrottle from "../../hooks/useThrottle";
 import { useAppStore } from "../../store/app-store";
 import { addHighlight, removeHighlight } from "../select-and-edit/utils";
 
+export interface Annotation {
+  selector: string;
+  description: string;
+}
+
 interface Props {
   code: string;
   device: "mobile" | "desktop";
   onScaleChange?: (scale: number) => void;
   viewMode?: "fit" | "actual";
+  annotations?: Annotation[];
 }
 
 const MOBILE_VIEWPORT_WIDTH = 375;
@@ -19,6 +25,7 @@ function PreviewComponent({
   device,
   onScaleChange,
   viewMode,
+  annotations,
 }: Props) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -157,6 +164,67 @@ function PreviewComponent({
       iframe.srcdoc = throttledCode;
     }
   }, [throttledCode]);
+
+  // Apply annotation highlights inside the iframe when annotations change
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe || !annotations || annotations.length === 0) return;
+
+    const applyAnnotations = () => {
+      const doc = iframe.contentWindow?.document;
+      if (!doc) return;
+
+      // Remove any previously injected annotation styles
+      doc.getElementById("__annotation-styles")?.remove();
+
+      // Inject a style tag with a pulsing highlight animation
+      const style = doc.createElement("style");
+      style.id = "__annotation-styles";
+      style.textContent = `
+        @keyframes __annotation-pulse {
+          0%, 100% { outline-color: rgba(245, 158, 11, 0.8); }
+          50% { outline-color: rgba(245, 158, 11, 0.3); }
+        }
+        .__annotation-highlight {
+          outline: 2px solid rgba(245, 158, 11, 0.8);
+          outline-offset: 2px;
+          animation: __annotation-pulse 2s ease-in-out 3;
+        }
+      `;
+      doc.head.appendChild(style);
+
+      // Query each selector and apply the highlight class
+      for (const annotation of annotations) {
+        try {
+          const el = doc.querySelector(annotation.selector);
+          if (el) {
+            el.classList.add("__annotation-highlight");
+            el.setAttribute("title", annotation.description);
+          }
+        } catch {
+          // Invalid selector — skip silently
+        }
+      }
+    };
+
+    // The iframe may not have loaded yet after srcdoc changes, so listen for load
+    iframe.addEventListener("load", applyAnnotations);
+    // Also try immediately in case the iframe is already loaded
+    applyAnnotations();
+
+    return () => {
+      iframe.removeEventListener("load", applyAnnotations);
+      // Clean up highlights from iframe DOM
+      const doc = iframe.contentWindow?.document;
+      if (doc) {
+        doc.getElementById("__annotation-styles")?.remove();
+        doc.querySelectorAll(".__annotation-highlight").forEach((el) => {
+          el.classList.remove("__annotation-highlight");
+          el.removeAttribute("title");
+        });
+      }
+    };
+  }, [annotations]);
 
   return (
     <div

--- a/frontend/src/components/preview/PreviewPane.tsx
+++ b/frontend/src/components/preview/PreviewPane.tsx
@@ -18,7 +18,7 @@ import { Button } from "../ui/button";
 import { useAppStore } from "../../store/app-store";
 import { useProjectStore } from "../../store/project-store";
 import { extractHtml } from "./extractHtml";
-import PreviewComponent from "./PreviewComponent";
+import PreviewComponent, { Annotation } from "./PreviewComponent";
 import { downloadCode } from "./download";
 
 function openInNewTab(code: string) {
@@ -68,6 +68,26 @@ function PreviewPane({ settings, onOpenVersions }: Props) {
     inputMode === "video" && appState === AppState.CODING
       ? extractHtml(currentCode)
       : currentCode;
+
+  // Extract annotations from the selected variant's completed annotate tool events
+  const annotations: Annotation[] = useMemo(() => {
+    if (!currentCommit) return [];
+    const variant = currentCommit.variants[currentCommit.selectedVariantIndex];
+    const events = variant?.agentEvents || [];
+    for (const event of events) {
+      if (
+        event.type === "tool" &&
+        event.toolName === "annotate" &&
+        event.status === "complete"
+      ) {
+        const output = event.output as { annotations?: Array<{ selector: string; description: string }> } | undefined;
+        if (output?.annotations && Array.isArray(output.annotations)) {
+          return output.annotations;
+        }
+      }
+    }
+    return [];
+  }, [currentCommit]);
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -217,6 +237,7 @@ function PreviewPane({ settings, onOpenVersions }: Props) {
             device="desktop"
             onScaleChange={setDesktopScale}
             viewMode={desktopViewMode}
+            annotations={annotations}
           />
         </TabsContent>
         <TabsContent value="mobile" className="flex-1 min-h-0 mt-0 data-[state=active]:flex data-[state=active]:flex-col">
@@ -224,6 +245,7 @@ function PreviewPane({ settings, onOpenVersions }: Props) {
             code={previewCode}
             device="mobile"
             viewMode="actual"
+            annotations={annotations}
           />
         </TabsContent>
         <TabsContent value="code" className="flex-1 min-h-0 mt-0 overflow-auto">


### PR DESCRIPTION
## Summary
This PR adds a new `annotate` tool that allows the agent to highlight and describe changed elements in the preview pane. When the agent completes code edits, it can call the annotate tool to visually mark which elements were modified and provide descriptions of the changes.

## Key Changes

- **Backend - Tool Definition & Runtime**
  - Added `annotate` tool definition in `backend/agent/tools/definitions.py` with schema for CSS selectors and change descriptions
  - Implemented `_annotate()` method in `backend/agent/tools/runtime.py` to validate and process annotation data
  - Added annotation summarization in `backend/agent/tools/summaries.py` to display annotations in activity logs
  - Updated system prompt to document the new annotate tool

- **Frontend - Preview Component**
  - Added `Annotation` interface to `PreviewComponent.tsx` with `selector` and `description` fields
  - Implemented annotation highlighting logic that:
    - Injects CSS with a pulsing amber outline animation
    - Applies highlights to elements matching the provided CSS selectors
    - Adds tooltip descriptions via title attributes
    - Handles iframe load timing and cleanup
  - Integrated annotations into `PreviewPane.tsx` to extract and pass them from completed agent events

- **Frontend - Activity Display**
  - Added annotation event rendering in `AgentActivity.tsx` with:
    - Tag icon (BsTag) for visual identification
    - Display of CSS selectors and descriptions in amber-themed cards
    - Proper event title handling for running/complete states

## Implementation Details

- Annotations are applied inside the iframe with a 2-second pulsing animation (3 iterations) using amber color (rgba(245, 158, 11))
- Invalid CSS selectors are silently skipped to prevent errors
- The annotation effect is cleaned up when the component unmounts or annotations change
- Annotations are extracted from the most recent completed `annotate` tool event in the current variant

https://claude.ai/code/session_01S3R2LH589n6nrSAJkfeDg8