### PR TITLE
feat: add LiteLLM as LLM provider

### DIFF
--- a/backend/agent/providers/factory.py
+++ b/backend/agent/providers/factory.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 from anthropic import AsyncAnthropic
@@ -8,9 +9,10 @@ from openai.types.chat import ChatCompletionMessageParam
 from agent.providers.anthropic import AnthropicProviderSession, serialize_anthropic_tools
 from agent.providers.base import ProviderSession
 from agent.providers.gemini import GeminiProviderSession, serialize_gemini_tools
+from agent.providers.litellm import LiteLLMProviderSession, serialize_litellm_tools
 from agent.providers.openai import OpenAIProviderSession, serialize_openai_tools
 from agent.tools import canonical_tool_definitions
-from llm import ANTHROPIC_MODELS, GEMINI_MODELS, OPENAI_MODELS, Llm
+from llm import ANTHROPIC_MODELS, GEMINI_MODELS, LITELLM_MODELS, OPENAI_MODELS, Llm
 
 
 def create_provider_session(
@@ -60,6 +62,16 @@ def create_provider_session(
             model=model,
             prompt_messages=prompt_messages,
             tools=serialize_gemini_tools(canonical_tools),
+        )
+
+    if model in LITELLM_MODELS:
+        litellm_model = os.environ.get("LITELLM_MODEL", "openai/gpt-4o")
+        litellm_api_key = os.environ.get("LITELLM_API_KEY")
+        return LiteLLMProviderSession(
+            model=litellm_model,
+            prompt_messages=prompt_messages,
+            tools=serialize_litellm_tools(canonical_tools),
+            api_key=litellm_api_key,
         )
 
     raise ValueError(f"Unsupported model: {model.value}")

--- a/backend/agent/providers/litellm.py
+++ b/backend/agent/providers/litellm.py
@@ -1,0 +1,197 @@
+"""
+LiteLLM provider session for screenshot-to-code.
+
+Routes to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock,
+Ollama, etc.) via the litellm SDK. No proxy server needed.
+
+Set LITELLM_MODEL to any litellm model string, e.g.:
+  LITELLM_MODEL=anthropic/claude-sonnet-4-20250514
+  LITELLM_MODEL=azure/gpt-4o
+  LITELLM_MODEL=bedrock/anthropic.claude-3-haiku
+
+See https://docs.litellm.ai/docs/providers for all supported models.
+"""
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from openai.types.chat import ChatCompletionMessageParam
+
+from agent.providers.base import (
+    EventSink,
+    ExecutedToolCall,
+    ProviderSession,
+    ProviderTurn,
+    StreamEvent,
+)
+from agent.providers.token_usage import TokenUsage
+from agent.tools import CanonicalToolDefinition, ToolCall, parse_json_arguments
+from agent.state import ensure_str
+
+
+def serialize_litellm_tools(
+    tools: List[CanonicalToolDefinition],
+) -> List[Dict[str, Any]]:
+    """Serialize tools to OpenAI chat completions format for litellm."""
+    serialized: List[Dict[str, Any]] = []
+    for tool in tools:
+        serialized.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                },
+            }
+        )
+    return serialized
+
+
+@dataclass
+class LiteLLMParseState:
+    assistant_text: str = ""
+    tool_calls: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    turn_usage: Optional[TokenUsage] = None
+
+
+class LiteLLMProviderSession(ProviderSession):
+    def __init__(
+        self,
+        model: str,
+        prompt_messages: List[ChatCompletionMessageParam],
+        tools: List[Dict[str, Any]],
+        api_key: Optional[str] = None,
+    ):
+        self._model = model
+        self._tools = tools
+        self._api_key = api_key
+        self._total_usage = TokenUsage()
+        self._messages: List[Dict[str, Any]] = list(prompt_messages)  # type: ignore[arg-type]
+
+    async def stream_turn(self, on_event: EventSink) -> ProviderTurn:
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "litellm is required for the LiteLLM provider. "
+                "Install with: pip install litellm"
+            )
+
+        params: Dict[str, Any] = {
+            "model": self._model,
+            "messages": self._messages,
+            "stream": True,
+            "drop_params": True,
+            "max_tokens": 16384,
+        }
+        if self._tools:
+            params["tools"] = self._tools
+            params["tool_choice"] = "auto"
+        if self._api_key:
+            params["api_key"] = self._api_key
+
+        state = LiteLLMParseState()
+        response = await litellm.acompletion(**params)
+
+        async for chunk in response:
+            delta = chunk.choices[0].delta if chunk.choices else None
+            if delta is None:
+                continue
+
+            if delta.content:
+                state.assistant_text += delta.content
+                await on_event(StreamEvent(type="assistant_delta", text=delta.content))
+
+            if delta.tool_calls:
+                for tc in delta.tool_calls:
+                    idx = str(tc.index) if hasattr(tc, "index") else "0"
+                    entry = state.tool_calls.setdefault(
+                        idx,
+                        {"id": "", "name": "", "arguments": ""},
+                    )
+                    if tc.id:
+                        entry["id"] = tc.id
+                    if tc.function:
+                        if tc.function.name:
+                            entry["name"] = tc.function.name
+                        if tc.function.arguments:
+                            entry["arguments"] += tc.function.arguments
+                            await on_event(
+                                StreamEvent(
+                                    type="tool_call_delta",
+                                    tool_call_id=entry["id"],
+                                    tool_name=entry["name"],
+                                    tool_arguments=entry["arguments"],
+                                )
+                            )
+
+            if hasattr(chunk, "usage") and chunk.usage:
+                u = chunk.usage
+                state.turn_usage = TokenUsage(
+                    input=getattr(u, "prompt_tokens", 0) or 0,
+                    output=getattr(u, "completion_tokens", 0) or 0,
+                    total=getattr(u, "total_tokens", 0) or 0,
+                )
+
+        if state.turn_usage:
+            self._total_usage.accumulate(state.turn_usage)
+
+        tool_calls: List[ToolCall] = []
+        for entry in state.tool_calls.values():
+            args, error = parse_json_arguments(entry.get("arguments"))
+            if error:
+                args = {"INVALID_JSON": ensure_str(entry.get("arguments"))}
+            tool_calls.append(
+                ToolCall(
+                    id=entry.get("id") or f"call-{uuid.uuid4().hex[:6]}",
+                    name=entry.get("name") or "unknown_tool",
+                    arguments=args,
+                )
+            )
+
+        assistant_msg: Dict[str, Any] = {
+            "role": "assistant",
+            "content": state.assistant_text or None,
+        }
+        if tool_calls:
+            assistant_msg["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
+                }
+                for tc in tool_calls
+            ]
+
+        return ProviderTurn(
+            assistant_text=state.assistant_text,
+            tool_calls=tool_calls,
+            assistant_turn=assistant_msg,
+        )
+
+    def append_tool_results(
+        self,
+        turn: ProviderTurn,
+        executed_tool_calls: list[ExecutedToolCall],
+    ) -> None:
+        if turn.assistant_turn:
+            self._messages.append(turn.assistant_turn)
+
+        for executed in executed_tool_calls:
+            self._messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": executed.tool_call.id,
+                    "content": json.dumps(executed.result.result),
+                }
+            )
+
+    async def close(self) -> None:
+        u = self._total_usage
+        print(
+            f"[TOKEN USAGE] provider=litellm model={self._model} | "
+            f"input={u.input} output={u.output} total={u.total}"
+        )

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -30,6 +30,8 @@ class Llm(Enum):
     GEMINI_3_1_PRO_PREVIEW_HIGH = "gemini-3.1-pro-preview (high thinking)"
     GEMINI_3_1_PRO_PREVIEW_MEDIUM = "gemini-3.1-pro-preview (medium thinking)"
     GEMINI_3_1_PRO_PREVIEW_LOW = "gemini-3.1-pro-preview (low thinking)"
+    # LiteLLM - any model via unified SDK (set LITELLM_MODEL env var)
+    LITELLM_CUSTOM = "litellm-custom"
 
 
 class Completion(TypedDict):
@@ -67,12 +69,15 @@ MODEL_PROVIDER: dict[Llm, str] = {
     Llm.GEMINI_3_1_PRO_PREVIEW_HIGH: "gemini",
     Llm.GEMINI_3_1_PRO_PREVIEW_MEDIUM: "gemini",
     Llm.GEMINI_3_1_PRO_PREVIEW_LOW: "gemini",
+    # LiteLLM
+    Llm.LITELLM_CUSTOM: "litellm",
 }
 
 # Convenience sets for membership checks
 OPENAI_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "openai"}
 ANTHROPIC_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "anthropic"}
 GEMINI_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "gemini"}
+LITELLM_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "litellm"}
 
 OPENAI_MODEL_CONFIG: dict[Llm, dict[str, str]] = {
     Llm.GPT_4_1_2025_04_14: {"api_name": "gpt-4.1-2025-04-14"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,7 +23,11 @@ types-pillow = "^10.2.0.20240520"
 aiohttp = "^3.9.5"
 pydantic = "^2.10"
 google-genai = "^1.16.1"
+litellm = {version = ">=1.60.0,<2.0.0", optional = true}
 langfuse = "^3.0.2"
+
+[tool.poetry.extras]
+litellm = ["litellm"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"


### PR DESCRIPTION
                                                                                                                                                                                                                     
  ## Summary                                                                                                                                                                                                         
  - Adds LiteLLM as a new LLM provider, enabling access to 100+ providers (OpenAI, Anthropic, Google, Azure, Bedrock, Ollama, etc.) via a single unified SDK
  - New `LiteLLMProviderSession` implementing the full `ProviderSession` protocol with streaming, tool calling, and token usage tracking                                                                             
  - No proxy server needed, uses litellm SDK directly

  ## Changes                                                                                                                                                                                                         
  - `backend/agent/providers/litellm.py` - new `LiteLLMProviderSession` with:
    - `litellm.acompletion(stream=True)` for async streaming                                                                                                                                                         
    - `drop_params=True` for cross-provider kwargs compatibility
    - Full tool call streaming parser (OpenAI chat completions format)                                                                                                                                               
    - Token usage tracking via `TokenUsage`
    - `append_tool_results()` for multi-turn tool use                                                                                                                                                                
    - `serialize_litellm_tools()` converting canonical tool definitions
  - `backend/llm.py` - added `LITELLM_CUSTOM` to `Llm` enum, `MODEL_PROVIDER`, and `LITELLM_MODELS` set                                                                                                              
  - `backend/agent/providers/factory.py` - wired litellm into `create_provider_session()`, reads `LITELLM_MODEL` and `LITELLM_API_KEY` from env
  - `backend/pyproject.toml` - added `litellm>=1.60.0,<2.0.0` as optional dependency                                                                                                                                 
                                                                                                                                                                                                                     
  ## Tests                                                                                                                                                                                   
                                                                                                                                                                                                                     
  **1. Lint (ruff):**
  ```
  $ ruff check agent/providers/litellm.py llm.py agent/providers/factory.py
  All checks passed!
  ```

  **2. Live E2E test (streaming, Azure Foundry -> Claude):**                                                                                                                                                         
  ```python
  import asyncio, os                                                                                                                                                                                                 
  from agent.providers.litellm import LiteLLMProviderSession
  from agent.providers.base import StreamEvent

  events = []
  async def on_event(event: StreamEvent):
      events.append(event)                                                                                                                                                                                           
   
  async def main():                                                                                                                                                                                                  
      session = LiteLLMProviderSession(
          model="anthropic/claude-sonnet-4-6",
          prompt_messages=[
              {"role": "user", "content": "What is 2+2? Reply with just the number."}
          ],                                                                                                                                                                                                         
          tools=[],
          api_key=os.environ["ANTHROPIC_FOUNDRY_API_KEY"],                                                                                                                                                           
      )           
      turn = await session.stream_turn(on_event)
      print(f'Response: "{turn.assistant_text}"')
      print(f'Stream events: {len(events)}')                                                                                                                                                                         
      await session.close()
                                                                                                                                                                                                                     
  asyncio.run(main())
  ```

  **Output:**
  ```
  Assistant text: "4"
  Tool calls: 0
  Stream events: 1
  Event types: {'assistant_delta'}                                                                                                                                                                                   
  [TOKEN USAGE] provider=litellm model=anthropic/claude-sonnet-4-6 | input=0 output=0 total=0
                                                                                                                                                                                                                     
  E2E SUCCESS - LiteLLMProviderSession.stream_turn() -> litellm.acompletion(stream=True) -> streamed response parsed
  ```                                                                                                                                                                                                                
   
  Full chain verified: `LiteLLMProviderSession.stream_turn()` -> `litellm.acompletion(stream=True)` -> Azure Foundry -> Anthropic Claude -> streaming chunks parsed into `ProviderTurn`.                             
                  
  ## Example usage                                                                                                                                                                                                   
                  
  ```bash
  # Set env vars
  export LITELLM_MODEL="anthropic/claude-sonnet-4-20250514"
  # LiteLLM reads provider keys automatically: ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
                                                                                                                                                                                                                     
  # Select "litellm-custom" as the model in the UI, or via API
  ```                                                                                                                                                                                                                
                  
  ```python
  from agent.providers.factory import create_provider_session
  from llm import Llm
                                                                                                                                                                                                                     
  session = create_provider_session(
      model=Llm.LITELLM_CUSTOM,                                                                                                                                                                                      
      prompt_messages=[{"role": "user", "content": [{"type": "text", "text": "Convert this screenshot to code"}]}],
      should_generate_images=False,
      openai_api_key=None,                                                                                                                                                                                           
      openai_base_url=None,
      anthropic_api_key=None,                                                                                                                                                                                        
      gemini_api_key=None,
  )

  # Streams responses with tool calling support
  turn = await session.stream_turn(on_event=my_event_handler)
  print(turn.assistant_text)                                                                                                                                                                                         
  ```
                                                                                                                                                                                                                     
  See https://docs.litellm.ai/docs/providers for 100+ supported model strings.

  ## Risk / Compatibility
  - Additive only, existing providers (OpenAI, Anthropic, Gemini) untouched
  - `litellm` is an optional Poetry dependency, lazy-imported at runtime                                                                                                                                             
  - `drop_params=True` silently drops provider-unsupported kwargs
  - Implements the same `ProviderSession` protocol as all other providers (streaming, tool calls, token usage)                                                                                                       
