### PR TITLE
Fix WebSocket double-close crash on abnormal client disconnection

### DIFF
--- a/backend/routes/generate_code.py
+++ b/backend/routes/generate_code.py
@@ -5,6 +5,7 @@ import traceback
 from typing import Callable, Awaitable
 from fastapi import APIRouter, WebSocket
 import openai
+from starlette.websockets import WebSocketDisconnect
 from websockets.exceptions import ConnectionClosedOK, ConnectionClosedError
 from config import (
     ANTHROPIC_API_KEY,
@@ -202,7 +203,7 @@ class WebSocketCommunicator:
             try:
                 await self.websocket.send_json({"type": "error", "value": message})
                 await self.websocket.close(APP_ERROR_WEB_SOCKET_CODE)
-            except (ConnectionClosedOK, ConnectionClosedError):
+            except (ConnectionClosedOK, ConnectionClosedError, RuntimeError, WebSocketDisconnect):
                 print("WebSocket already closed by client")
             self.is_closed = True
 
@@ -217,8 +218,8 @@ class WebSocketCommunicator:
         if not self.is_closed:
             try:
                 await self.websocket.close()
-            except (ConnectionClosedOK, ConnectionClosedError):
-                pass  # Already closed by client
+            except (ConnectionClosedOK, ConnectionClosedError, RuntimeError, WebSocketDisconnect):
+                pass  # Already closed by client or ASGI layer
             self.is_closed = True
 
 


### PR DESCRIPTION
Fixes #599

## Problem

When a client connects to `/generate-code` and disconnects abnormally (close code 1006) before sending parameters, the backend crashes with a `RuntimeError`:

```
starlette.websockets.WebSocketDisconnect: (<CloseCode.ABNORMAL_CLOSURE: 1006>, None)

RuntimeError: Unexpected ASGI message 'websocket.close', after sending 'websocket.close' or response already completed.
```

The `WebSocketDisconnect` exception propagates up from `receive_params()`, then the `finally` block in `WebSocketSetupMiddleware` calls `ws_comm.close()` on an already-closed socket. The `close()` method only caught `ConnectionClosedOK` and `ConnectionClosedError`, missing `RuntimeError` and `WebSocketDisconnect` which uvicorn raises in this scenario.

## Fix

- Import `WebSocketDisconnect` from starlette
- Add `RuntimeError` and `WebSocketDisconnect` to the exception handlers in both `close()` and `throw_error()` on `WebSocketCommunicator`

## Testing

All 113 existing tests pass.