### PR TITLE
Fix .mov file uploads: handle missing MIME type in browsers like Firefox

### DIFF
--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -38,23 +38,46 @@ const rejectStyle = {
 };
 
 // TODO: Move to a separate file
+// Map file extensions to MIME types as a fallback when the browser
+// does not report the correct MIME type (e.g., Firefox for .mov files)
+function inferMimeType(file: File): string {
+  if (file.type) {
+    return file.type;
+  }
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  const extensionToMime: Record<string, string> = {
+    mov: "video/quicktime",
+    mp4: "video/mp4",
+    webm: "video/webm",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+  };
+  return ext && extensionToMime[ext] ? extensionToMime[ext] : "";
+}
+
 function fileToDataURL(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {
       const result = reader.result as string;
-      // Check if the MIME type is correctly set in the data URL
-      // Some browsers return application/octet-stream for video files
-      if (result.startsWith("data:application/octet-stream") && file.type) {
-        // Replace with the correct MIME type from the file
-        const correctedResult = result.replace(
-          "data:application/octet-stream",
-          `data:${file.type}`
-        );
-        resolve(correctedResult);
-      } else {
-        resolve(result);
+      // Some browsers return application/octet-stream for video files.
+      // Infer the correct MIME type from file.type or file extension.
+      if (result.startsWith("data:application/octet-stream")) {
+        const mimeType = inferMimeType(file);
+        if (mimeType) {
+          resolve(
+            result.replace(
+              "data:application/octet-stream",
+              `data:${mimeType}`
+            )
+          );
+          return;
+        }
       }
+      resolve(result);
     };
     reader.onerror = (error) => reject(error);
     reader.readAsDataURL(file);

--- a/frontend/src/components/unified-input/tabs/UploadTab.tsx
+++ b/frontend/src/components/unified-input/tabs/UploadTab.tsx
@@ -9,20 +9,46 @@ import OutputSettingsSection from "../../settings/OutputSettingsSection";
 import { DesignSystemSelectorProps } from "../../settings/DesignSystemSelector";
 import { Stack } from "../../../lib/stacks";
 
+// Map file extensions to MIME types as a fallback when the browser
+// does not report the correct MIME type (e.g., Firefox for .mov files)
+function inferMimeType(file: File): string {
+  if (file.type) {
+    return file.type;
+  }
+  const ext = file.name.split(".").pop()?.toLowerCase();
+  const extensionToMime: Record<string, string> = {
+    mov: "video/quicktime",
+    mp4: "video/mp4",
+    webm: "video/webm",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    webp: "image/webp",
+  };
+  return ext && extensionToMime[ext] ? extensionToMime[ext] : "";
+}
+
 function fileToDataURL(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {
       const result = reader.result as string;
-      if (result.startsWith("data:application/octet-stream") && file.type) {
-        const correctedResult = result.replace(
-          "data:application/octet-stream",
-          `data:${file.type}`
-        );
-        resolve(correctedResult);
-      } else {
-        resolve(result);
+      // Some browsers return application/octet-stream for video files.
+      // Infer the correct MIME type from file.type or file extension.
+      if (result.startsWith("data:application/octet-stream")) {
+        const mimeType = inferMimeType(file);
+        if (mimeType) {
+          resolve(
+            result.replace(
+              "data:application/octet-stream",
+              `data:${mimeType}`
+            )
+          );
+          return;
+        }
       }
+      resolve(result);
     };
     reader.onerror = (error) => reject(error);
     reader.readAsDataURL(file);


### PR DESCRIPTION
### Problem

When uploading a `.mov` video file, the browser (particularly Firefox) sometimes reports an empty MIME type (`file.type === ""`). This causes `FileReader.readAsDataURL()` to produce a data URL with `data:application/octet-stream;base64,...` instead of the correct `data:video/quicktime;base64,...`.

The existing `fileToDataURL()` function had a fallback that only ran when `file.type` was non-empty, so the MIME type was never corrected for these browsers. The incorrect `application/octet-stream` prefix then caused files to be misclassified downstream.

### Root Cause

The condition `result.startsWith("data:application/octet-stream") && file.type` skipped the MIME correction when `file.type` was an empty string (a falsy value in JavaScript).

### Fix

Added an `inferMimeType()` helper that:
1. Uses `file.type` when available (same as before)
2. Falls back to mapping the file extension to a known MIME type when `file.type` is empty

The extension-to-MIME mapping covers `.mov`, `.mp4`, `.webm`, `.png`, `.jpg/.jpeg`, `.gif`, and `.webp`.

The fix is applied to both file upload components:
- `frontend/src/components/ImageUpload.tsx`
- `frontend/src/components/unified-input/tabs/UploadTab.tsx`

Fixes #384