### PR TITLE
Add Frontend dev-hosted task to Zed configuration

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -8,6 +8,14 @@
     "reveal": "always"
   },
   {
+    "label": "Frontend dev-hosted",
+    "command": "pnpm run dev-hosted",
+    "cwd": "$ZED_WORKTREE_ROOT/frontend",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always"
+  },
+  {
     "label": "Backend dev",
     "command": "poetry run uvicorn main:app --reload --port 7001",
     "cwd": "$ZED_WORKTREE_ROOT/backend",


### PR DESCRIPTION
## Summary
Added a new Zed task configuration for running the frontend in dev-hosted mode, enabling developers to test the frontend against the hosted/SaaS backend.

## Changes
- Added "Frontend dev-hosted" task to `.zed/tasks.json` that runs `pnpm run dev-hosted` in the frontend directory
- Task is configured to run in the existing terminal (not a new one) and will always reveal output
- Positioned logically after the existing "Frontend dev" task in the configuration file

## Details
This task allows developers to easily switch between testing against the local backend (existing "Frontend dev" task) and the hosted SaaS backend (new "Frontend dev-hosted" task) without manually running commands in the terminal.

https://claude.ai/code/session_01XTeNsvf3HqNX5xhCtF2Sgn