### PR TITLE
Preserve partial generation on disconnect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -403,6 +403,15 @@ function App() {
       });
     };
 
+    const markGeneratingVariantsErrored = (message: string) => {
+      const latestCommit = useProjectStore.getState().commits[commit.hash];
+      latestCommit?.variants.forEach((variant, variantIndex) => {
+        if (variant.status === "generating") {
+          updateVariantStatus(commit.hash, variantIndex, "error", message);
+        }
+      });
+    };
+
     generateCode(wsRef, updatedParams, {
       onChange: (token, variantIndex) => {
         appendCommitCode(commit.hash, variantIndex, token);
@@ -525,20 +534,21 @@ function App() {
 
         // Close any running agent events when the socket ends without per-event
         // terminal messages, otherwise they remain stuck in "running" state.
-        finishInFlightEvents(reason === "request_failed" ? "error" : "complete");
+        finishInFlightEvents(reason === "user_cancelled" ? "complete" : "error");
+
+        if (reason === "connection_error") {
+          markGeneratingVariantsErrored(
+            errorMessage ||
+              "Connection lost before generation completed. Partial output was preserved."
+          );
+          setAppState(AppState.CODE_READY);
+          return;
+        }
 
         if (reason === "request_failed" && commit.type === "ai_create") {
-          const latestCreateCommit = useProjectStore.getState().commits[commit.hash];
-          latestCreateCommit?.variants.forEach((variant, variantIndex) => {
-            if (variant.status === "generating") {
-              updateVariantStatus(
-                commit.hash,
-                variantIndex,
-                "error",
-                errorMessage || "Generation failed. Please retry."
-              );
-            }
-          });
+          markGeneratingVariantsErrored(
+            errorMessage || "Generation failed. Please retry."
+          );
           setAppState(AppState.CODE_READY);
           return;
         }

--- a/frontend/src/generateCode.ts
+++ b/frontend/src/generateCode.ts
@@ -13,6 +13,14 @@ const CANCEL_MESSAGE = "Code generation cancelled";
 const CONNECTION_LOST_MESSAGE =
   "Connection lost while generating. Partial output was preserved.";
 
+type WebSocketResponseData = {
+  models?: string[];
+  name?: string;
+  input?: unknown;
+  ok?: boolean;
+  output?: unknown;
+};
+
 type WebSocketResponse = {
   type:
     | "chunk"
@@ -28,7 +36,7 @@ type WebSocketResponse = {
     | "toolStart"
     | "toolResult";
   value?: string;
-  data?: any;
+  data?: WebSocketResponseData;
   eventId?: string;
   variantIndex: number;
 };
@@ -43,8 +51,16 @@ interface CodeGenerationCallbacks {
   onVariantModels: (models: string[]) => void;
   onThinking: (content: string, variantIndex: number, eventId?: string) => void;
   onAssistant: (content: string, variantIndex: number, eventId?: string) => void;
-  onToolStart: (data: any, variantIndex: number, eventId?: string) => void;
-  onToolResult: (data: any, variantIndex: number, eventId?: string) => void;
+  onToolStart: (
+    data: WebSocketResponseData | undefined,
+    variantIndex: number,
+    eventId?: string
+  ) => void;
+  onToolResult: (
+    data: WebSocketResponseData | undefined,
+    variantIndex: number,
+    eventId?: string
+  ) => void;
   onCancel: (
     reason: "user_cancelled" | "request_failed" | "connection_error",
     errorMessage?: string

--- a/frontend/src/generateCode.ts
+++ b/frontend/src/generateCode.ts
@@ -10,6 +10,8 @@ const ERROR_MESSAGE =
   "Error generating code. Check the Developer Console AND the backend logs for details. Feel free to open a Github issue.";
 
 const CANCEL_MESSAGE = "Code generation cancelled";
+const CONNECTION_LOST_MESSAGE =
+  "Connection lost while generating. Partial output was preserved.";
 
 type WebSocketResponse = {
   type:
@@ -105,8 +107,11 @@ export function generateCode(
       callbacks.onCancel("request_failed", event.reason || ERROR_MESSAGE);
     } else if (event.code !== 1000) {
       console.error("Unknown server or connection error", event);
-      toast.error(ERROR_MESSAGE);
-      callbacks.onCancel("connection_error", event.reason || ERROR_MESSAGE);
+      toast.error(CONNECTION_LOST_MESSAGE);
+      callbacks.onCancel(
+        "connection_error",
+        event.reason || CONNECTION_LOST_MESSAGE
+      );
     } else {
       callbacks.onComplete();
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Preserve in-progress generation output when the WebSocket disconnects unexpectedly.
- Mark unfinished variants as errored and return the UI to the code review state instead of resetting.
- Show a connection-loss message that explains partial output was preserved.
- Tighten the generation WebSocket payload typing in the touched file.

### Walkthrough
[disconnect_preserves_partial_landing_page.mp4](https://cursor.com/agents/bc-019f1b0e-63bb-7b5d-a600-8cc5872ec2b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdisconnect_preserves_partial_landing_page.mp4)

[Connection lost with partial landing page preserved](https://cursor.com/agents/bc-019f1b0e-63bb-7b5d-a600-8cc5872ec2b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdisconnect_preserves_partial_landing_page.webp)

### Testing
- Passed: `pnpm exec eslint src/App.tsx src/generateCode.ts --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- Passed: `pnpm exec tsc --noEmit`
- Manual: fake WebSocket backend streamed a partial SaaS landing page and then dropped the transport; the UI preserved the partial landing page and showed the connection-loss error.
- Warning: full `pnpm lint` still fails on existing repository lint debt outside this change.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b0e-63bb-7b5d-a600-8cc5872ec2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b0e-63bb-7b5d-a600-8cc5872ec2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

