### PR TITLE
feat: add OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Running locally requires API keys and a backend/frontend setup. The app has a Re
 
 ### API keys
 
-You need **at least one** model provider key (OpenAI, Anthropic, or Gemini).
+You need **at least one** model provider key (OpenAI, Anthropic, Gemini, or OrcaRouter).
 **Gemini and Replicate are strongly recommended for the best quality of
 screenshot-to-code accuracy** — Gemini powers asset extraction (reusing the
 real logos/images from your screenshot) and Replicate powers image
@@ -48,9 +48,10 @@ the best results and lets you compare multiple models per generation.
 
 | Key | Required? | What it unlocks |
 |-----|-----------|-----------------|
-| `OPENAI_API_KEY` | One of these three | GPT code-gen variants (GPT-5.5, GPT-5.4 Mini) |
-| `ANTHROPIC_API_KEY` | One of these three | Claude code-gen variants (Opus 5, Opus 4.8, Fable 5, Sonnet 4.6) |
-| `GEMINI_API_KEY` | One of these three — **strongly recommended** | Gemini code-gen variants (3 Flash, 3.1 Pro); extracts real assets from the screenshot; required for video mode |
+| `OPENAI_API_KEY` | One of these four | GPT code-gen variants (GPT-5.5, GPT-5.4 Mini) |
+| `ANTHROPIC_API_KEY` | One of these four | Claude code-gen variants (Opus 5, Opus 4.8, Fable 5, Sonnet 4.6) |
+| `GEMINI_API_KEY` | One of these four — **strongly recommended** | Gemini code-gen variants (3 Flash, 3.1 Pro); extracts real assets from the screenshot; required for video mode |
+| `ORCAROUTER_API_KEY` | One of these four | [OrcaRouter](https://www.orcarouter.ai) gateway (auto-routed `orcarouter/auto` code-gen variant) |
 | `REPLICATE_API_KEY` | **Strongly recommended** | Image editing, background removal, and Replicate-backed image generation — without it, `edit_images` and `remove_backgrounds` are unavailable |
 
 With more keys, the app automatically picks a stronger mix of models per
@@ -66,6 +67,7 @@ echo "OPENAI_API_KEY=sk-your-key" > .env
 echo "ANTHROPIC_API_KEY=your-key" >> .env
 echo "GEMINI_API_KEY=your-key" >> .env
 echo "REPLICATE_API_KEY=r8_your-key" >> .env
+echo "ORCAROUTER_API_KEY=sk-orca-your-key" >> .env
 poetry install
 # Install the Chromium browser used by the screenshot preview tool.
 # On Linux, use `poetry run playwright install --with-deps chromium` to also
@@ -76,7 +78,7 @@ poetry env activate
 poetry run uvicorn main:app --reload --port 7001
 ```
 
-You can also set up OpenAI, Anthropic, and Gemini keys using the settings dialog in the frontend (click the gear icon after loading the app). Replicate must be configured in `backend/.env` as `REPLICATE_API_KEY`. The Settings dialog also shows whether **screenshot preview** is available on your backend.
+You can also set up OpenAI, Anthropic, Gemini, and OrcaRouter keys using the settings dialog in the frontend (click the gear icon after loading the app). Replicate must be configured in `backend/.env` as `REPLICATE_API_KEY`. The Settings dialog also shows whether **screenshot preview** is available on your backend.
 
 > **Screenshot preview** (optional) lets the agent render its own generated page in a headless browser and visually check its work. It's enabled automatically once Chromium is installed (the `playwright install chromium` step above, or automatically in the Docker image). If Chromium is missing, the app just skips the tool — the Settings dialog shows whether it's available.
 

--- a/backend/agent/engine.py
+++ b/backend/agent/engine.py
@@ -67,6 +67,8 @@ class AgentEngine:
         initial_file_state: Optional[Dict[str, str]] = None,
         option_codes: Optional[List[str]] = None,
         recorder: Optional[AgentRunRecorder] = None,
+        orcarouter_api_key: Optional[str] = None,
+        orcarouter_base_url: Optional[str] = None,
     ):
         self.send_message = send_message
         self.variant_index = variant_index
@@ -76,6 +78,8 @@ class AgentEngine:
         self.anthropic_api_key = anthropic_api_key
         self.gemini_api_key = gemini_api_key
         self.replicate_api_key = replicate_api_key
+        self.orcarouter_api_key = orcarouter_api_key
+        self.orcarouter_base_url = orcarouter_base_url
         self.should_generate_images = should_generate_images
         self.should_extract_assets = should_extract_assets
 
@@ -93,6 +97,8 @@ class AgentEngine:
             replicate_api_key=replicate_api_key,
             asset_base_url=asset_base_url,
             option_codes=option_codes,
+            orcarouter_api_key=self.orcarouter_api_key,
+            orcarouter_base_url=self.orcarouter_base_url,
         )
         self._tool_preview_lengths: Dict[str, int] = {}
 
@@ -350,6 +356,8 @@ class AgentEngine:
                 self.should_extract_assets and bool(self.tool_runtime.input_images)
             ),
             recorder=self.recorder,
+            orcarouter_api_key=self.orcarouter_api_key,
+            orcarouter_base_url=self.orcarouter_base_url,
         )
         try:
             result = await self._run_with_session(session)

--- a/backend/agent/providers/factory.py
+++ b/backend/agent/providers/factory.py
@@ -12,7 +12,13 @@ from agent.providers.openai import OpenAIProviderSession, serialize_openai_tools
 from agent.tools import canonical_tool_definitions
 from config import REPLICATE_API_KEY
 from fs_logging.agent_runs import AgentRunRecorder
-from llm import ANTHROPIC_MODELS, GEMINI_MODELS, OPENAI_MODELS, Llm
+from llm import (
+    ANTHROPIC_MODELS,
+    GEMINI_MODELS,
+    OPENAI_MODELS,
+    ORCAROUTER_MODELS,
+    Llm,
+)
 from preview_screenshot import is_screenshot_preview_available
 
 
@@ -27,6 +33,8 @@ def create_provider_session(
     replicate_api_key: Optional[str],
     should_extract_assets: bool = True,
     recorder: Optional[AgentRunRecorder] = None,
+    orcarouter_api_key: Optional[str] = None,
+    orcarouter_base_url: Optional[str] = None,
 ) -> ProviderSession:
     canonical_tools = canonical_tool_definitions(
         image_generation_enabled=should_generate_images,
@@ -74,6 +82,22 @@ def create_provider_session(
             model=model,
             prompt_messages=prompt_messages,
             tools=serialize_gemini_tools(canonical_tools),
+            recorder=recorder,
+        )
+
+    if model in ORCAROUTER_MODELS:
+        if not orcarouter_api_key:
+            raise Exception("OrcaRouter API key is missing.")
+
+        client = AsyncOpenAI(
+            api_key=orcarouter_api_key,
+            base_url=orcarouter_base_url or "https://api.orcarouter.ai/v1",
+        )
+        return OpenAIProviderSession(
+            client=client,
+            model=model,
+            prompt_messages=prompt_messages,
+            tools=serialize_openai_tools(canonical_tools),
             recorder=recorder,
         )
 

--- a/backend/agent/tools/runtime.py
+++ b/backend/agent/tools/runtime.py
@@ -38,6 +38,8 @@ class AgentToolRuntime:
         asset_base_url: str = "",
         user_id: Optional[str] = None,
         option_codes: Optional[List[str]] = None,
+        orcarouter_api_key: Optional[str] = None,
+        orcarouter_base_url: Optional[str] = None,
     ):
         self.file_state = file_state
         self.should_generate_images = should_generate_images
@@ -45,6 +47,8 @@ class AgentToolRuntime:
         self.openai_base_url = openai_base_url
         self.gemini_api_key = gemini_api_key
         self.replicate_api_key = replicate_api_key
+        self.orcarouter_api_key = orcarouter_api_key
+        self.orcarouter_base_url = orcarouter_base_url
         self.input_images = input_images or []
         self.asset_base_url = asset_base_url
         self.user_id = user_id

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,6 +9,12 @@ ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", None)
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", None)
 OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", None)
 
+# OrcaRouter gateway (OpenAI-compatible). https://www.orcarouter.ai
+ORCAROUTER_API_KEY = os.environ.get("ORCAROUTER_API_KEY", None)
+ORCAROUTER_BASE_URL = os.environ.get(
+    "ORCAROUTER_BASE_URL", "https://api.orcarouter.ai/v1"
+)
+
 # Image generation (optional)
 REPLICATE_API_KEY = os.environ.get("REPLICATE_API_KEY", None)
 

--- a/backend/evals/core.py
+++ b/backend/evals/core.py
@@ -7,9 +7,11 @@ from config import (
     LOCAL_ASSET_BASE_URL,
     OPENAI_API_KEY,
     OPENAI_BASE_URL,
+    ORCAROUTER_API_KEY,
+    ORCAROUTER_BASE_URL,
     REPLICATE_API_KEY,
 )
-from llm import Llm, OPENAI_MODELS, ANTHROPIC_MODELS, GEMINI_MODELS
+from llm import Llm, OPENAI_MODELS, ANTHROPIC_MODELS, GEMINI_MODELS, ORCAROUTER_MODELS
 from agent.runner import Agent
 from fs_logging.agent_runs import AgentRunRecorder
 from prompts.create.image import build_image_prompt_messages
@@ -44,6 +46,8 @@ async def _run_eval_agent(
         raise Exception("Gemini API key not found")
     if model in OPENAI_MODELS and not OPENAI_API_KEY:
         raise Exception("OpenAI API key not found")
+    if model in ORCAROUTER_MODELS and not ORCAROUTER_API_KEY:
+        raise Exception("OrcaRouter API key not found")
 
     print(f"[EVALS] Using agent runner for model: {model.value}")
 
@@ -75,6 +79,8 @@ async def _run_eval_agent(
         initial_file_state=None,
         option_codes=None,
         recorder=recorder,
+        orcarouter_api_key=ORCAROUTER_API_KEY,
+        orcarouter_base_url=ORCAROUTER_BASE_URL,
     )
     return await runner.run(model, prompt_messages)
 

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -54,6 +54,8 @@ class Llm(Enum):
     GEMINI_3_6_FLASH_MEDIUM = "gemini-3.6-flash (medium thinking)"
     GEMINI_3_6_FLASH_LOW = "gemini-3.6-flash (low thinking)"
     GEMINI_3_6_FLASH_MINIMAL = "gemini-3.6-flash (minimal thinking)"
+    # OrcaRouter
+    ORCAROUTER_AUTO = "orcarouter/auto"
 
 
 class Completion(TypedDict):
@@ -115,12 +117,15 @@ MODEL_PROVIDER: dict[Llm, str] = {
     Llm.GEMINI_3_6_FLASH_MEDIUM: "gemini",
     Llm.GEMINI_3_6_FLASH_LOW: "gemini",
     Llm.GEMINI_3_6_FLASH_MINIMAL: "gemini",
+    # OrcaRouter models
+    Llm.ORCAROUTER_AUTO: "orcarouter",
 }
 
 # Convenience sets for membership checks
 OPENAI_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "openai"}
 ANTHROPIC_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "anthropic"}
 GEMINI_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "gemini"}
+ORCAROUTER_MODELS = {m for m, p in MODEL_PROVIDER.items() if p == "orcarouter"}
 
 OPENAI_MODEL_CONFIG: dict[Llm, dict[str, str]] = {
     Llm.GPT_5_4_MINI_LOW: {"api_name": "gpt-5.4-mini", "reasoning_effort": "low"},
@@ -156,6 +161,7 @@ OPENAI_MODEL_CONFIG: dict[Llm, dict[str, str]] = {
     Llm.GPT_5_6_SOL_XHIGH: {"api_name": "gpt-5.6-sol", "reasoning_effort": "xhigh"},
     Llm.GPT_5_6_SOL_MAX: {"api_name": "gpt-5.6-sol", "reasoning_effort": "max"},
     Llm.GPT_5_6_TERRA_LOW: {"api_name": "gpt-5.6-terra", "reasoning_effort": "low"},
+    Llm.ORCAROUTER_AUTO: {"api_name": "orcarouter/auto"},
 }
 
 

--- a/backend/routes/generate_code.py
+++ b/backend/routes/generate_code.py
@@ -18,6 +18,8 @@ from config import (
     NUM_VARIANTS_VIDEO,
     OPENAI_API_KEY,
     OPENAI_BASE_URL,
+    ORCAROUTER_API_KEY,
+    ORCAROUTER_BASE_URL,
     REPLICATE_API_KEY,
 )
 from custom_types import InputMode
@@ -73,6 +75,7 @@ from routes.model_choice_sets import (
     GEMINI_ONLY_MODELS,
     OPENAI_ANTHROPIC_MODELS,
     OPENAI_ONLY_MODELS,
+    ORCAROUTER_VARIANT_MODELS,
     VIDEO_VARIANT_MODELS,
 )
 
@@ -268,6 +271,8 @@ class ExtractedParams:
     should_extract_assets: bool = True
     asset_base_url: str = ""
     design_system: str | None = None
+    orcarouter_api_key: str | None = None
+    orcarouter_base_url: str | None = None
 
 
 class ParameterExtractionStage:
@@ -323,6 +328,15 @@ class ParameterExtractionStage:
             )
         if not openai_base_url:
             print("Using official OpenAI URL")
+
+        # OrcaRouter gateway (OpenAI-compatible). Key/base URL come from the
+        # settings dialog (orcarouterApiKey) or backend/.env (ORCAROUTER_API_KEY).
+        orcarouter_api_key = self._get_from_settings_dialog_or_env(
+            params, "orcarouterApiKey", ORCAROUTER_API_KEY
+        )
+        orcarouter_base_url = self._get_from_settings_dialog_or_env(
+            params, "orcarouterBaseURL", ORCAROUTER_BASE_URL
+        )
 
         # Feature preferences default to enabled for older clients.
         should_generate_images = bool(params.get("isImageGenerationEnabled", True))
@@ -383,6 +397,8 @@ class ParameterExtractionStage:
             gemini_api_key=gemini_api_key,
             replicate_api_key=replicate_api_key,
             openai_base_url=openai_base_url,
+            orcarouter_api_key=orcarouter_api_key,
+            orcarouter_base_url=orcarouter_base_url,
             generation_type=generation_type,
             prompt=prompt,
             history=history,
@@ -421,6 +437,7 @@ class ModelSelectionStage:
         openai_api_key: str | None,
         anthropic_api_key: str | None,
         gemini_api_key: str | None = None,
+        orcarouter_api_key: str | None = None,
     ) -> List[Llm]:
         """Select appropriate models based on available API keys"""
         try:
@@ -432,6 +449,7 @@ class ModelSelectionStage:
                 openai_api_key,
                 anthropic_api_key,
                 gemini_api_key,
+                orcarouter_api_key,
             )
 
             # Print the variant models (one per line)
@@ -442,8 +460,8 @@ class ModelSelectionStage:
             return variant_models
         except Exception:
             await self.throw_error(
-                "No OpenAI, Anthropic, or Gemini API key found. Please add the environment variable "
-                "OPENAI_API_KEY, ANTHROPIC_API_KEY, or GEMINI_API_KEY to backend/.env or in the settings dialog. "
+                "No OpenAI, Anthropic, Gemini, or OrcaRouter API key found. Please add the environment variable "
+                "OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, or ORCAROUTER_API_KEY to backend/.env or in the settings dialog. "
                 "If you add it to .env, make sure to restart the backend server."
             )
             raise Exception("No API key")
@@ -456,6 +474,7 @@ class ModelSelectionStage:
         openai_api_key: str | None,
         anthropic_api_key: str | None,
         gemini_api_key: str | None,
+        orcarouter_api_key: str | None = None,
     ) -> List[Llm]:
         """Simple model cycling that scales with num_variants"""
 
@@ -468,8 +487,11 @@ class ModelSelectionStage:
                 )
             return list(VIDEO_VARIANT_MODELS)
 
-        # Define models based on available API keys
-        if gemini_api_key and anthropic_api_key and openai_api_key:
+        # OrcaRouter is a first-class provider: when its key is configured the
+        # OrcaRouter gateway model is used for every variant.
+        if orcarouter_api_key:
+            models = list(ORCAROUTER_VARIANT_MODELS)
+        elif gemini_api_key and anthropic_api_key and openai_api_key:
             if input_mode == "text" and generation_type == "create":
                 models = list(ALL_KEYS_MODELS_TEXT_CREATE)
             elif generation_type == "update":
@@ -489,7 +511,7 @@ class ModelSelectionStage:
         elif openai_api_key:
             models = list(OPENAI_ONLY_MODELS)
         else:
-            raise Exception("No OpenAI or Anthropic key")
+            raise Exception("No OpenAI, Anthropic, or OrcaRouter key")
 
         # Cycle through models: [A, B] with num=5 becomes [A, B, A, B, A]
         selected_models: List[Llm] = []
@@ -566,6 +588,8 @@ class AgenticGenerationStage:
         stack: str | None = None,
         input_mode: str | None = None,
         generation_type: str | None = None,
+        orcarouter_api_key: str | None = None,
+        orcarouter_base_url: str | None = None,
     ):
         self.send_message = send_message
         self.openai_api_key = openai_api_key
@@ -573,6 +597,8 @@ class AgenticGenerationStage:
         self.anthropic_api_key = anthropic_api_key
         self.gemini_api_key = gemini_api_key
         self.replicate_api_key = replicate_api_key
+        self.orcarouter_api_key = orcarouter_api_key
+        self.orcarouter_base_url = orcarouter_base_url
         self.should_generate_images = should_generate_images
         self.should_extract_assets = should_extract_assets
         self.file_state = file_state
@@ -654,6 +680,8 @@ class AgenticGenerationStage:
                 initial_file_state=self.file_state,
                 option_codes=self.option_codes,
                 recorder=recorder,
+                orcarouter_api_key=self.orcarouter_api_key,
+                orcarouter_base_url=self.orcarouter_base_url,
             )
             completion = await runner.run(model, prompt_messages)
             if completion:
@@ -815,6 +843,7 @@ class CodeGenerationMiddleware(Middleware):
                 openai_api_key=context.extracted_params.openai_api_key,
                 anthropic_api_key=context.extracted_params.anthropic_api_key,
                 gemini_api_key=context.extracted_params.gemini_api_key,
+                orcarouter_api_key=context.extracted_params.orcarouter_api_key,
             )
             if IS_DEBUG_ENABLED:
                 await context.send_message(
@@ -840,6 +869,8 @@ class CodeGenerationMiddleware(Middleware):
                 stack=str(context.extracted_params.stack),
                 input_mode=str(context.extracted_params.input_mode),
                 generation_type=context.extracted_params.generation_type,
+                orcarouter_api_key=context.extracted_params.orcarouter_api_key,
+                orcarouter_base_url=context.extracted_params.orcarouter_base_url,
             )
 
             context.variant_completions = await generation_stage.process_variants(

--- a/backend/routes/model_choice_sets.py
+++ b/backend/routes/model_choice_sets.py
@@ -6,6 +6,12 @@ VIDEO_VARIANT_MODELS = (
     Llm.GEMINI_3_1_PRO_PREVIEW_HIGH,
 )
 
+# OrcaRouter gateway variants. `orcarouter/auto` routes each request to the
+# best available model automatically.
+ORCAROUTER_VARIANT_MODELS = (
+    Llm.ORCAROUTER_AUTO,
+)
+
 # All API keys available.
 
 # Image (Create)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -93,6 +93,8 @@ function App() {
       replicateApiKey: null,
       anthropicApiKey: null,
       geminiApiKey: null,
+      orcarouterApiKey: null,
+      orcarouterBaseURL: "https://api.orcarouter.ai/v1",
       screenshotOneApiKey: null,
       isImageGenerationEnabled: true,
       editorTheme: EditorTheme.COBALT,

--- a/frontend/src/components/settings/SettingsTab.tsx
+++ b/frontend/src/components/settings/SettingsTab.tsx
@@ -224,6 +224,43 @@ function SettingsTab({ settings, setSettings, appTheme, setAppTheme }: Props) {
                 />
               </div>
 
+              <div>
+                <p className="text-sm font-medium text-gray-700 dark:text-zinc-300">
+                  OrcaRouter API key
+                </p>
+                <p className="mt-1 text-xs text-gray-500 dark:text-zinc-400">
+                  Use <a href="https://www.orcarouter.ai" target="_blank" rel="noreferrer" className="underline">OrcaRouter</a> for automatic
+                  model routing. Only stored in your browser. Overrides your
+                  .env config.
+                </p>
+                <Input
+                  id="orcarouter-api-key"
+                  className="mt-2"
+                  placeholder="sk-orca-..."
+                  value={settings.orcarouterApiKey || ""}
+                  onChange={(e) =>
+                    setSettings((s) => ({
+                      ...s,
+                      orcarouterApiKey: e.target.value,
+                    }))
+                  }
+                />
+                {!IS_RUNNING_ON_CLOUD && (
+                  <Input
+                    id="orcarouter-base-url"
+                    className="mt-2"
+                    placeholder="OrcaRouter Base URL"
+                    value={settings.orcarouterBaseURL || ""}
+                    onChange={(e) =>
+                      setSettings((s) => ({
+                        ...s,
+                        orcarouterBaseURL: e.target.value,
+                      }))
+                    }
+                  />
+                )}
+              </div>
+
               {!IS_RUNNING_ON_CLOUD && (
                 <div>
                   <p className="text-sm font-medium text-gray-700 dark:text-zinc-300">

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -39,6 +39,7 @@ export enum CodeGenerationModel {
   GEMINI_3_6_FLASH_MEDIUM = "gemini-3.6-flash (medium thinking)",
   GEMINI_3_6_FLASH_LOW = "gemini-3.6-flash (low thinking)",
   GEMINI_3_6_FLASH_MINIMAL = "gemini-3.6-flash (minimal thinking)",
+  ORCAROUTER_AUTO = "orcarouter/auto",
 }
 
 export type VariantLabelTone = "fast" | "max";
@@ -191,5 +192,8 @@ export const CODE_GENERATION_MODEL_DESCRIPTIONS: {
   },
   "gemini-3.1-pro-preview (low thinking)": {
     name: "Gemini 3.1 Pro (low)",
+  },
+  "orcarouter/auto": {
+    name: "OrcaRouter (auto)",
   },
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -26,6 +26,8 @@ export interface Settings {
   isTermOfServiceAccepted: boolean;
   anthropicApiKey: string | null;
   geminiApiKey: string | null;
+  orcarouterApiKey: string | null;
+  orcarouterBaseURL: string | null;
 }
 
 export interface DesignSystem {


### PR DESCRIPTION
## Add OrcaRouter as a named OpenAI-compatible provider

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a first-class model provider alongside OpenAI, Anthropic, and Gemini. OrcaRouter is an OpenAI-compatible gateway that routes each request to the best available model automatically via `orcarouter/auto`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **`backend/llm.py`** — register `orcarouter/auto` and expose `ORCAROUTER_MODELS`.
- **`backend/agent/providers/factory.py`** — dispatch OrcaRouter models to the existing OpenAI-compatible Responses session, pointed at `https://api.orcarouter.ai/v1`.
- **`backend/routes/generate_code.py`** — accept `ORCAROUTER_API_KEY` from `backend/.env` or the settings dialog; when set, use the OrcaRouter gateway model for every variant.
- **`backend/config.py`, `backend/evals/core.py`, `backend/agent/engine.py`, `backend/agent/tools/runtime.py`** — thread the OrcaRouter key/base URL through the agent pipeline and eval runner.
- **`frontend`** — add OrcaRouter API key + base URL fields to the Settings dialog, and register `orcarouter/auto` in `lib/models.ts`.
- **`README.md`** — document the new key.

### How it works

The app already has an OpenAI-compatible code path that talks to the Responses API with configurable `base_url`. OrcaRouter exposes the same endpoint shape, so this reuses that proven session — no new transport or streaming code.

### Verification

- Backend: `pytest` — **276 passed**.
- Frontend: `tsc --noEmit` clean, `eslint` clean on changed files, `jest` — **42 passed**.
- Live: a real request through the new provider path (via `create_provider_session` for `orcarouter/auto`) returned a streaming 200 response from `https://api.orcarouter.ai/v1/responses`.

Disclosure: I'm an engineer on the OrcaRouter team.
