### PR TITLE
Add account-free temporary preview publishing

### DIFF
--- a/frontend/src/components/preview/PreviewPane.tsx
+++ b/frontend/src/components/preview/PreviewPane.tsx
@@ -23,6 +23,8 @@ import { downloadCode } from "./download";
 import { SelectAndEditToolbarButton } from "../select-and-edit/SelectAndEditControls";
 import { normalizeBabelCdn } from "../../lib/babelCdn";
 import ImageScanningPreview from "./ImageScanningPreview";
+import { TemporaryPreviewButton } from "./TemporaryPreviewButton";
+import { getProjectKey } from "./tempPreviewStorage";
 
 function prepareHtmlForNewTab(code: string) {
   const html = normalizeBabelCdn(code);
@@ -88,6 +90,10 @@ function PreviewPane({ settings, onOpenVersions }: Props) {
 
   const canSelectAndEdit =
     appState === AppState.CODE_READY || !!isSelectedVariantComplete;
+  const projectKey = useMemo(
+    () => getProjectKey(commits, head),
+    [commits, head]
+  );
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -204,16 +210,22 @@ function PreviewPane({ settings, onOpenVersions }: Props) {
                 <SelectAndEditToolbarButton />
               )}
             {(appState === AppState.CODE_READY || isSelectedVariantComplete) && (
-              <Button
-                onClick={() => downloadCode(previewCode)}
-                variant="ghost"
-                size="icon"
-                title="Download Code"
-                className="h-9 w-9"
-                data-testid="download-code"
-              >
-                <LuDownload />
-              </Button>
+              <>
+                <TemporaryPreviewButton
+                  code={previewCode}
+                  projectKey={projectKey}
+                />
+                <Button
+                  onClick={() => downloadCode(previewCode)}
+                  variant="ghost"
+                  size="icon"
+                  title="Download Code"
+                  className="h-9 w-9"
+                  data-testid="download-code"
+                >
+                  <LuDownload />
+                </Button>
+              </>
             )}
             <Button
               onClick={() => {

--- a/frontend/src/components/preview/TemporaryPreviewButton.tsx
+++ b/frontend/src/components/preview/TemporaryPreviewButton.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useState } from "react";
+import copy from "copy-to-clipboard";
+import toast from "react-hot-toast";
+import {
+  LuCopy,
+  LuExternalLink,
+  LuLink,
+  LuLoader2,
+  LuRefreshCw,
+  LuTrash2,
+} from "react-icons/lu";
+import {
+  isStaleTempPreviewError,
+  publishTempPreview,
+  revokeTempPreview,
+  type TempPreviewConnection,
+} from "../../lib/tempPreview";
+import { Button } from "../ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import {
+  loadTempPreview,
+  removeTempPreview,
+  saveTempPreview,
+} from "./tempPreviewStorage";
+
+interface Props {
+  code: string;
+  projectKey: string | null;
+}
+
+export function TemporaryPreviewButton({ code, projectKey }: Props) {
+  const [connection, setConnection] = useState<TempPreviewConnection | null>(null);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  useEffect(() => {
+    setConnection(projectKey ? loadTempPreview(projectKey) : null);
+  }, [projectKey]);
+
+  const handlePublish = async () => {
+    if (!projectKey || !code.trim()) return;
+    setIsPublishing(true);
+    try {
+      let nextConnection: TempPreviewConnection;
+      let updatedExistingPreview = Boolean(connection);
+      try {
+        nextConnection = await publishTempPreview({
+          html: code,
+          previous: connection,
+        });
+      } catch (error) {
+        if (!connection || !isStaleTempPreviewError(error)) throw error;
+        removeTempPreview(projectKey);
+        nextConnection = await publishTempPreview({ html: code });
+        updatedExistingPreview = false;
+      }
+
+      saveTempPreview(projectKey, nextConnection);
+      setConnection(nextConnection);
+      copy(nextConnection.canonicalUrl);
+      toast.success(
+        updatedExistingPreview
+          ? "Temporary preview updated and link copied"
+          : "Temporary preview published and link copied"
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to publish temporary preview"
+      );
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  const handleCopy = () => {
+    if (!connection) return;
+    copy(connection.canonicalUrl);
+    toast.success("Preview link copied");
+  };
+
+  const handleRemove = async () => {
+    if (!projectKey || !connection) return;
+    setIsRemoving(true);
+    try {
+      await revokeTempPreview(connection);
+      removeTempPreview(projectKey);
+      setConnection(null);
+      toast.success("Temporary preview removed");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove temporary preview"
+      );
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          title="Publish Temporary Preview"
+          className="h-9 w-9"
+          data-testid="temporary-preview-trigger"
+        >
+          <LuLink />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 space-y-3">
+        <div>
+          <div className="text-sm font-semibold text-gray-900 dark:text-zinc-100">
+            Temporary preview
+          </div>
+          <p className="mt-1 text-xs leading-5 text-gray-500 dark:text-zinc-400">
+            Publish the current HTML to temp.md for 7 days. Anyone with the link
+            can view it. No account required.
+          </p>
+        </div>
+
+        {connection ? (
+          <>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="flex w-full items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-left text-xs text-gray-700 hover:bg-gray-100 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              title="Copy preview link"
+            >
+              <span className="min-w-0 flex-1 truncate">{connection.canonicalUrl}</span>
+              <LuCopy className="shrink-0" />
+            </button>
+            <div className="text-[11px] text-gray-500 dark:text-zinc-500">
+              Expires {formatExpiry(connection.expiresAt)}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={handlePublish}
+                disabled={isPublishing || isRemoving}
+                className="flex-1 gap-1.5"
+                data-testid="publish-temp-preview"
+              >
+                {isPublishing ? (
+                  <LuLoader2 className="animate-spin" />
+                ) : (
+                  <LuRefreshCw />
+                )}
+                Update
+              </Button>
+              <Button type="button" size="sm" variant="outline" asChild>
+                <a
+                  href={connection.canonicalUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="gap-1.5"
+                >
+                  <LuExternalLink />
+                  Open
+                </a>
+              </Button>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                onClick={handleRemove}
+                disabled={isPublishing || isRemoving}
+                title="Remove temporary preview"
+                className="h-8 w-8 text-gray-500 hover:text-red-600"
+              >
+                {isRemoving ? (
+                  <LuLoader2 className="animate-spin" />
+                ) : (
+                  <LuTrash2 />
+                )}
+              </Button>
+            </div>
+          </>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            onClick={handlePublish}
+            disabled={isPublishing || !projectKey}
+            className="w-full gap-1.5"
+            data-testid="publish-temp-preview"
+          >
+            {isPublishing && <LuLoader2 className="animate-spin" />}
+            Publish preview
+          </Button>
+        )}
+
+        <a
+          href="https://temp.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block text-center text-[11px] text-gray-400 hover:text-gray-600 dark:text-zinc-600 dark:hover:text-zinc-400"
+        >
+          Temporary hosting by temp.md
+        </a>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function formatExpiry(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "in 7 days";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/frontend/src/components/preview/tempPreviewStorage.test.ts
+++ b/frontend/src/components/preview/tempPreviewStorage.test.ts
@@ -1,0 +1,84 @@
+import { Commit } from "../commits/types";
+import {
+  getProjectKey,
+  loadTempPreview,
+  removeTempPreview,
+  saveTempPreview,
+} from "./tempPreviewStorage";
+
+function commit(hash: string, parentHash: string | null): Commit {
+  return {
+    hash,
+    parentHash,
+    dateCreated: new Date(),
+    isCommitted: true,
+    variants: [{ code: "<html></html>", history: [] }],
+    selectedVariantIndex: 0,
+    type: "code_create",
+    inputs: null,
+  };
+}
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+describe("temporary preview persistence", () => {
+  it("uses the root commit as the stable project key across versions", () => {
+    const commits = {
+      root: commit("root", null),
+      edit: commit("edit", "root"),
+      latest: commit("latest", "edit"),
+    };
+
+    expect(getProjectKey(commits, "root")).toBe("root");
+    expect(getProjectKey(commits, "latest")).toBe("root");
+  });
+
+  it("saves, loads, and removes a scoped connection", () => {
+    const storage = new MemoryStorage();
+    const connection = {
+      tempId: "temp-1",
+      canonicalUrl: "https://preview.temp.md",
+      updateToken: "secret",
+      expiresAt: "2026-08-31T00:00:00.000Z",
+    };
+
+    saveTempPreview("root", connection, storage);
+    expect(loadTempPreview("root", storage)).toEqual(connection);
+
+    removeTempPreview("root", storage);
+    expect(loadTempPreview("root", storage)).toBeNull();
+  });
+
+  it("ignores malformed local data", () => {
+    const storage = new MemoryStorage();
+    storage.setItem("screenshot-to-code.temp-previews.v1", "not json");
+
+    expect(loadTempPreview("root", storage)).toBeNull();
+  });
+});

--- a/frontend/src/components/preview/tempPreviewStorage.ts
+++ b/frontend/src/components/preview/tempPreviewStorage.ts
@@ -1,0 +1,79 @@
+import type { Commit } from "../commits/types";
+import type { TempPreviewConnection } from "../../lib/tempPreview";
+
+const STORAGE_KEY = "screenshot-to-code.temp-previews.v1";
+
+export function getProjectKey(
+  commits: Record<string, Commit>,
+  head: string | null
+): string | null {
+  if (!head || !commits[head]) return null;
+
+  let current = commits[head];
+  const visited = new Set<string>();
+  while (current.parentHash && commits[current.parentHash]) {
+    if (visited.has(current.hash)) return null;
+    visited.add(current.hash);
+    current = commits[current.parentHash];
+  }
+  return current.hash;
+}
+
+export function loadTempPreview(
+  projectKey: string,
+  storage: Storage = window.localStorage
+): TempPreviewConnection | null {
+  const records = readRecords(storage);
+  return records[projectKey] ?? null;
+}
+
+export function saveTempPreview(
+  projectKey: string,
+  connection: TempPreviewConnection,
+  storage: Storage = window.localStorage
+): void {
+  const records = readRecords(storage);
+  records[projectKey] = connection;
+  storage.setItem(STORAGE_KEY, JSON.stringify(records));
+}
+
+export function removeTempPreview(
+  projectKey: string,
+  storage: Storage = window.localStorage
+): void {
+  const records = readRecords(storage);
+  delete records[projectKey];
+  storage.setItem(STORAGE_KEY, JSON.stringify(records));
+}
+
+function readRecords(storage: Storage): Record<string, TempPreviewConnection> {
+  try {
+    const value = storage.getItem(STORAGE_KEY);
+    if (!value) return {};
+    const parsed: unknown = JSON.parse(value);
+    if (!isRecord(parsed)) return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, TempPreviewConnection] =>
+          isTempPreviewConnection(entry[1])
+      )
+    );
+  } catch {
+    return {};
+  }
+}
+
+function isTempPreviewConnection(value: unknown): value is TempPreviewConnection {
+  return (
+    isRecord(value) &&
+    typeof value.tempId === "string" &&
+    typeof value.canonicalUrl === "string" &&
+    typeof value.updateToken === "string" &&
+    typeof value.expiresAt === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/frontend/src/lib/tempPreview.test.ts
+++ b/frontend/src/lib/tempPreview.test.ts
@@ -1,0 +1,133 @@
+import {
+  isStaleTempPreviewError,
+  publishTempPreview,
+  revokeTempPreview,
+  TempPreviewConnection,
+  TempPreviewError,
+} from "./tempPreview";
+
+const previous: TempPreviewConnection = {
+  tempId: "temp-existing",
+  canonicalUrl: "https://existing.temp.md",
+  updateToken: "update-secret",
+  expiresAt: "2026-08-31T00:00:00.000Z",
+};
+
+describe("publishTempPreview", () => {
+  it("creates a preview from normalized HTML", async () => {
+    const fetcher = jest.fn<
+      Promise<Response>,
+      [RequestInfo | URL, RequestInit?]
+    >(async (_url, init) => {
+      const formData = init?.body as FormData;
+      const file = formData.get("file") as File;
+      expect(await file.text()).toContain("@babel/standalone@7.25.6");
+      return Response.json(
+        {
+          tempId: "temp-new",
+          canonicalUrl: "https://new-preview.temp.md",
+          updateToken: "new-secret",
+          expiresAt: "2026-08-31T00:00:00.000Z",
+        },
+        { status: 201 }
+      );
+    });
+
+    const result = await publishTempPreview({
+      html: '<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>',
+      fetcher,
+      baseUrl: "https://api.example.test/",
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/temps",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(result.canonicalUrl).toBe("https://new-preview.temp.md");
+  });
+
+  it("updates an existing preview and retains its scoped token", async () => {
+    const fetcher = jest.fn<
+      Promise<Response>,
+      [RequestInfo | URL, RequestInit?]
+    >(async () =>
+      Response.json({
+        tempId: previous.tempId,
+        canonicalUrl: previous.canonicalUrl,
+        versionId: "version-2",
+        expiresAt: "2026-09-01T00:00:00.000Z",
+      })
+    );
+
+    const result = await publishTempPreview({
+      html: "<html><body>Updated</body></html>",
+      previous,
+      fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.temp.md/temps/temp-existing",
+      expect.objectContaining({
+        method: "PUT",
+        headers: { Authorization: "Bearer update-secret" },
+      })
+    );
+    expect(result.updateToken).toBe(previous.updateToken);
+    expect(result.expiresAt).toBe("2026-09-01T00:00:00.000Z");
+  });
+
+  it("surfaces safe API error messages and stale capabilities", async () => {
+    const fetcher = jest.fn<
+      Promise<Response>,
+      [RequestInfo | URL, RequestInit?]
+    >(async () =>
+      Response.json({ message: "This Temp is unavailable." }, { status: 410 })
+    );
+
+    const publish = publishTempPreview({
+      html: "<html></html>",
+      previous,
+      fetcher,
+    });
+
+    await expect(publish).rejects.toMatchObject({
+      message: "This Temp is unavailable.",
+      status: 410,
+    });
+    await publish.catch((error) => {
+      expect(isStaleTempPreviewError(error)).toBe(true);
+    });
+  });
+});
+
+describe("revokeTempPreview", () => {
+  it("revokes with the stored capability", async () => {
+    const fetcher = jest.fn<
+      Promise<Response>,
+      [RequestInfo | URL, RequestInit?]
+    >(async () => new Response(null, { status: 204 }));
+
+    await revokeTempPreview(previous, fetcher);
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.temp.md/temps/temp-existing",
+      {
+        method: "DELETE",
+        headers: { Authorization: "Bearer update-secret" },
+      }
+    );
+  });
+
+  it("marks authorization failures as typed errors", async () => {
+    const fetcher = jest.fn<
+      Promise<Response>,
+      [RequestInfo | URL, RequestInit?]
+    >(async () =>
+      Response.json({ error: "Invalid update token" }, { status: 403 })
+    );
+
+    await expect(revokeTempPreview(previous, fetcher)).rejects.toBeInstanceOf(
+      TempPreviewError
+    );
+  });
+});

--- a/frontend/src/lib/tempPreview.ts
+++ b/frontend/src/lib/tempPreview.ts
@@ -1,0 +1,157 @@
+import { normalizeBabelCdn } from "./babelCdn";
+
+const DEFAULT_TEMP_MD_API_URL = "https://api.temp.md";
+
+export interface TempPreviewConnection {
+  tempId: string;
+  canonicalUrl: string;
+  updateToken: string;
+  expiresAt: string;
+}
+
+export class TempPreviewError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+    this.name = "TempPreviewError";
+  }
+}
+
+interface PublishOptions {
+  html: string;
+  previous?: TempPreviewConnection | null;
+  fetcher?: Fetcher;
+  baseUrl?: string;
+}
+
+type Fetcher = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export async function publishTempPreview({
+  html,
+  previous,
+  fetcher = fetch,
+  baseUrl = DEFAULT_TEMP_MD_API_URL,
+}: PublishOptions): Promise<TempPreviewConnection> {
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new Blob([normalizeBabelCdn(html)], { type: "text/html" }),
+    "index.html"
+  );
+
+  const response = await fetcher(
+    previous
+      ? `${trimTrailingSlash(baseUrl)}/temps/${encodeURIComponent(previous.tempId)}`
+      : `${trimTrailingSlash(baseUrl)}/temps`,
+    {
+      method: previous ? "PUT" : "POST",
+      headers: previous
+        ? { Authorization: `Bearer ${previous.updateToken}` }
+        : undefined,
+      body: formData,
+    }
+  );
+
+  const body = await readJson(response);
+  if (!response.ok) {
+    throw new TempPreviewError(
+      getErrorMessage(body) ?? `Publishing failed with status ${response.status}`,
+      response.status
+    );
+  }
+
+  const connection = parsePublishResponse(body, previous);
+  if (!connection) {
+    throw new TempPreviewError("temp.md returned an invalid response", response.status);
+  }
+  return connection;
+}
+
+export async function revokeTempPreview(
+  connection: TempPreviewConnection,
+  fetcher: Fetcher = fetch,
+  baseUrl = DEFAULT_TEMP_MD_API_URL
+): Promise<void> {
+  const response = await fetcher(
+    `${trimTrailingSlash(baseUrl)}/temps/${encodeURIComponent(connection.tempId)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${connection.updateToken}` },
+    }
+  );
+
+  if (response.ok || response.status === 404 || response.status === 410) return;
+
+  const body = await readJson(response);
+  throw new TempPreviewError(
+    getErrorMessage(body) ?? `Removing the preview failed with status ${response.status}`,
+    response.status
+  );
+}
+
+export function isStaleTempPreviewError(error: unknown): boolean {
+  return (
+    error instanceof TempPreviewError &&
+    [401, 403, 404, 410].includes(error.status)
+  );
+}
+
+function parsePublishResponse(
+  body: unknown,
+  previous?: TempPreviewConnection | null
+): TempPreviewConnection | null {
+  if (!isRecord(body)) return null;
+
+  const { tempId, canonicalUrl, expiresAt } = body;
+  const updateToken = body.updateToken ?? previous?.updateToken;
+  if (
+    typeof tempId !== "string" ||
+    typeof canonicalUrl !== "string" ||
+    typeof updateToken !== "string" ||
+    typeof expiresAt !== "string"
+  ) {
+    return null;
+  }
+
+  try {
+    new URL(canonicalUrl);
+  } catch {
+    return null;
+  }
+
+  if (Number.isNaN(Date.parse(expiresAt))) return null;
+
+  return { tempId, canonicalUrl, updateToken, expiresAt };
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function getErrorMessage(body: unknown): string | null {
+  if (!isRecord(body)) return null;
+  if (typeof body.message === "string" && body.message.trim()) {
+    return body.message;
+  }
+  if (typeof body.error === "string" && body.error.trim()) {
+    return body.error;
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}

--- a/frontend/src/tests/qa.test.ts
+++ b/frontend/src/tests/qa.test.ts
@@ -173,7 +173,7 @@ describeE2E("qa e2e flows", () => {
     );
   });
 
-  // Buttons (Download Code, Copy Code, Open in Codepen)
+  // Buttons (Download Code, Copy Code, Open in Codepen, Temporary Preview)
   models.forEach((model) => {
     it(
       `code action buttons: ${model}`,
@@ -350,16 +350,24 @@ class App {
     await this.page.click('[data-testid="copy-code"]');
     await this.page.click('[data-testid="open-codepen"]');
     await this.page.click('[data-testid="download-code"]');
+    await this.page.click('[data-testid="temporary-preview-trigger"]');
+    await this.page.click('[data-testid="publish-temp-preview"]');
+    await this.page.waitForFunction(
+      () => document.body.innerText.includes("https://qa-preview.temp.md"),
+      { timeout: 10000 }
+    );
 
     const results = await this.page.evaluate(() => ({
       downloads: window.__qaDownloads,
       submits: window.__qaFormSubmits,
       clipboard: window.__qaClipboardCalls,
+      previews: localStorage.getItem("screenshot-to-code.temp-previews.v1"),
     }));
 
     expect(results.downloads).toContain("index.html");
     expect(results.submits).toContain("https://codepen.io/pen/define");
     expect(results.clipboard).toContain("copy");
+    expect(results.previews).toContain("https://qa-preview.temp.md");
   }
 }
 
@@ -398,6 +406,23 @@ async function setupRequestInterception(
             'attachment; filename="screenshot-to-code-export.zip"',
         },
         body: "mock export",
+      });
+      return;
+    }
+    if (url === "https://api.temp.md/temps") {
+      request.respond({
+        status: 201,
+        contentType: "application/json",
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Headers": "*",
+        },
+        body: JSON.stringify({
+          tempId: "qa-temp",
+          canonicalUrl: "https://qa-preview.temp.md",
+          updateToken: "qa-update-token",
+          expiresAt: "2026-08-31T00:00:00.000Z",
+        }),
       });
       return;
     }


### PR DESCRIPTION
## Summary

- add an explicit Temporary preview action beside Download Code for completed previews
- publish the selected HTML only after a user click, then copy the public URL
- support stable URL updates plus open, copy, and revoke controls
- persist only the project-scoped update capability in local storage
- disclose the 7-day lifetime, public-link visibility, and third-party temp.md hosting in the UI
- recover from expired or revoked capabilities by creating a fresh preview

## Privacy and service disclosure

I maintain temp.md, the third-party service used by this integration. No content is uploaded until the user explicitly clicks Publish preview. Published previews are public to anyone with the URL and expire after seven days. Account, API-key, repository, and deployment setup are not required.

The narrowly scoped browser CORS prerequisite has been merged separately in https://github.com/huangdun/tempmd/pull/2; its production rollout is pending.

## Verification

- Jest: 50 passed, 6 skipped
- TypeScript typecheck passed
- Vite production build passed
- ESLint passed for every changed TypeScript file
- added unit coverage for create, update, revoke, error handling, stale capabilities, and per-project persistence
- extended the existing optional QA flow for the toolbar action

The repository-wide lint command still reports existing violations in untouched files.

Closes #623