### PR TITLE
Update the README default Claude model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Default AI models:
 
 - Gemini 3 Flash Preview and Gemini 3.1 Pro Preview - the best models
 - GPT-5.5 and GPT-5.4 Mini
-- Claude Opus 4.6, Claude Opus 4.8
+- Claude Opus 5, Claude Opus 4.8
 - z-image-turbo (using Replicate) for image generation
 
 See the [Examples](#-examples) section below for more demos.


### PR DESCRIPTION
## Problem

The README lists Claude Opus 4.6 as a default model, but the current backend enum, provider configuration, model selection, and tests no longer contain it.

## Solution

Replace the obsolete README model name with Claude Opus 5, which is present in the current default model-selection configuration.

## Verification

- Confirmed the removed model and Opus 5 replacement in the current backend configuration and tests.
- Parsed all 135 tracked Python sources with the built-in compiler: 0 syntax errors.
- Checked 20 Markdown sources and 12 relative links: 0 unresolved local links.
- node --check passed for all four tracked JavaScript/CJS config files.
- git diff --check.

No user screenshot, account, credential, model/API, payment, telemetry, or production service was used.