### PR TITLE
Harden CORS config and block SSRF in screenshot preview

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -40,10 +40,15 @@ async def probe_screenshot_preview_on_startup() -> None:
     await probe_screenshot_preview()
 
 # Configure CORS settings
+# allow_credentials=False: this backend has no cookie/session auth, so there
+# is nothing worth stealing via credentialed cross-origin requests. Wildcard
+# origins + allow_credentials=True is a known-bad combination (browsers
+# reject it, but scanners flag it, and it invites mistakes if cookie auth is
+# ever added later) — keep it False rather than pairing it with "*".
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/preview_screenshot/playwright_backend.py
+++ b/backend/preview_screenshot/playwright_backend.py
@@ -1,9 +1,13 @@
 import asyncio
+import ipaddress
+import socket
 from typing import Optional
+from urllib.parse import urlparse
 
 from playwright.async_api import (
     Browser,
     Playwright,
+    Route,
     TimeoutError as PlaywrightTimeoutError,
     async_playwright,
 )
@@ -12,6 +16,74 @@ from preview_screenshot.base import VIEWPORT_SIZES
 
 PAGE_LOAD_TIMEOUT_MS = 15000
 RENDER_SETTLE_MS = 250
+
+# Only these hostnames are trusted to reach loopback: the /local-assets/
+# route this same backend serves. Everything else that resolves to a
+# loopback, private, or link-local address (including cloud metadata
+# endpoints like 169.254.169.254) is blocked so that LLM-generated HTML
+# can't turn this browser into an SSRF proxy into the local network.
+ALLOWED_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+# Schemes that never touch the network and are always safe to allow.
+_NETWORKLESS_SCHEMES = {"data", "blob", "about", "javascript"}
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip.is_loopback
+        or ip.is_private
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _resolve_is_blocked(hostname: str) -> bool:
+    """Resolve `hostname` and report whether any address is internal/local.
+
+    Unresolvable hostnames are blocked too, rather than let them through.
+    """
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return True
+
+    for info in infos:
+        raw_ip = info[4][0]
+        try:
+            ip = ipaddress.ip_address(raw_ip)
+        except ValueError:
+            continue
+        if _is_blocked_ip(ip):
+            return True
+    return False
+
+
+async def _guard_request(route: Route) -> None:
+    request = route.request
+    parsed = urlparse(request.url)
+
+    if parsed.scheme in _NETWORKLESS_SCHEMES:
+        await route.continue_()
+        return
+
+    if parsed.scheme not in ("http", "https"):
+        await route.abort()
+        return
+
+    hostname = (parsed.hostname or "").lower()
+    if hostname in ALLOWED_LOOPBACK_HOSTS:
+        await route.continue_()
+        return
+
+    loop = asyncio.get_event_loop()
+    blocked = await loop.run_in_executor(None, _resolve_is_blocked, hostname)
+    if blocked:
+        await route.abort()
+        return
+
+    await route.continue_()
 
 
 class PlaywrightBackend:
@@ -69,6 +141,7 @@ class PlaywrightBackend:
             viewport={"width": width, "height": height},
             device_scale_factor=1,
         )
+        await page.route("**/*", _guard_request)
         try:
             try:
                 await page.set_content(


### PR DESCRIPTION
## Summary
- `backend/main.py`: drop `allow_credentials=True` paired with `allow_origins=["*"]`. This backend has no cookie/session auth, so the credentialed-wildcard combination had no upside and is a known-bad CORS pattern flagged by scanners.
- `backend/preview_screenshot/playwright_backend.py`: the `screenshot_preview` tool renders LLM-generated HTML in a real headless Chromium with full network access. Added a `page.route()` guard that resolves each request's hostname and blocks loopback/private/link-local targets (including cloud metadata endpoints like `169.254.169.254`), while still allowing `localhost`/`127.0.0.1` so the existing `/local-assets/` image flow keeps working.

## Why
Without the guard, a crafted prompt could get the model to emit HTML containing a `fetch`/`<img>` to an internal service or a cloud metadata endpoint, and the server-side headless browser would dutifully make that request and could leak the response back into the rendered screenshot — a server-side request forgery (SSRF) path. The CORS setting was a secondary hardening item found in the same pass.

## Test plan
- [x] `poetry run pytest` (ran in an isolated venv with the same pinned deps since Poetry wasn't available locally) — 276 passed
- [x] `poetry run pyright` on the two changed files — 0 errors
- [ ] Maintainer sanity-check: confirm `screenshot_preview` still renders `/local-assets/` images correctly, and that no other legitimate use case needs a blocked address range