### PR TITLE
fix: keep Playwright reload compatible on Windows

### DIFF
--- a/backend/start.py
+++ b/backend/start.py
@@ -1,5 +1,7 @@
 import argparse
+import asyncio
 import socket
+import sys
 
 import uvicorn
 
@@ -26,6 +28,12 @@ def find_available_port(host: str, start_port: int, max_attempts: int) -> int:
     )
 
 
+def configure_event_loop() -> None:
+    """Use a subprocess-capable event loop for Playwright on Windows."""
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")
@@ -37,4 +45,8 @@ if __name__ == "__main__":
     if port != args.port:
         print(f"Port {args.port} is in use. Starting backend on port {port}.")
 
-    uvicorn.run("main:app", host=args.host, port=port, reload=True)
+    configure_event_loop()
+    # Uvicorn's asyncio setup deliberately switches to SelectorEventLoop when
+    # reload is enabled on Windows. Playwright needs ProactorEventLoop for its
+    # child-process transport, so leave loop setup to configure_event_loop().
+    uvicorn.run("main:app", host=args.host, port=port, reload=True, loop="none")

--- a/backend/tests/test_start.py
+++ b/backend/tests/test_start.py
@@ -9,3 +9,21 @@ def test_find_available_port_skips_bound_port(monkeypatch):
     )
 
     assert start.find_available_port("127.0.0.1", 7001, 20) == 7003
+
+
+def test_configure_event_loop_uses_proactor_on_windows(monkeypatch):
+    policy = object()
+    calls = []
+
+    monkeypatch.setattr(start.sys, "platform", "win32")
+    monkeypatch.setattr(
+        start.asyncio,
+        "WindowsProactorEventLoopPolicy",
+        lambda: policy,
+        raising=False,
+    )
+    monkeypatch.setattr(start.asyncio, "set_event_loop_policy", calls.append)
+
+    start.configure_event_loop()
+
+    assert calls == [policy]


### PR DESCRIPTION
Fixes #636\n\nUvicorn switches to SelectorEventLoop when reload is enabled on Windows, which prevents Playwright from spawning Chromium. Configure the Proactor policy and leave Uvicorn loop setup disabled so reload keeps a subprocess-capable event loop.\n\nValidated with python -m pytest tests/test_start.py (2 passed) and python -m py_compile backend/start.py backend/tests/test_start.py.